### PR TITLE
Removed version.sbt: leave it to sbt-ci-release

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"


### PR DESCRIPTION
The explicit version that was in `version.sbt` was preventing sbt-ci-release from computing the version number.