### PR TITLE
Compiler parses into UntypedOperation (Untyped[Query|Mutation|Subscription])

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,13 @@ bin/
 # Mill
 out/
 
+# VSCode
+.vscode/
+
 # Bloop/Metals
 .bloop/
 .metals/
+metals.sbt
 
 # Vim
 *.swp

--- a/modules/core/src/main/scala/operation.scala
+++ b/modules/core/src/main/scala/operation.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+
+import Query._
+
+sealed trait UntypedOperation {
+  val query: Query
+  val variables: UntypedVarDefs
+}
+object UntypedOperation {
+  case class UntypedQuery(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
+  case class UntypedMutation(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
+  case class UntypedSubscription(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
+}

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -9,7 +9,7 @@ import cats.implicits._
 import cats.tests.CatsSuite
 
 import edu.gemini.grackle._
-import Query._, Predicate._, Value._
+import Query._, Predicate._, Value._, UntypedOperation._
 import QueryCompiler._, ComponentElaborator.TrivialJoin
 
 final class CompilerSuite extends CatsSuite {
@@ -28,7 +28,47 @@ final class CompilerSuite extends CatsSuite {
       )
 
     val res = QueryParser.parseText(text)
-    assert(res == Ior.Right((expected, Nil)))
+    assert(res == Ior.Right(UntypedQuery(expected, Nil)))
+  }
+
+ test("simple mutation") {
+    val text = """
+      mutation {
+        update_character(id: "1000", name: "Luke") {
+          character {
+            name
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("update_character", List(Binding("id", StringValue("1000")), Binding("name", StringValue("Luke"))),
+        Select("character", Nil,
+          Select("name", Nil)
+        )
+      )
+
+    val res = QueryParser.parseText(text)
+    assert(res == Ior.Right(UntypedMutation(expected, Nil)))
+  }
+
+  test("simple subscription") {
+    val text = """
+      subscription {
+        character(id: "1000") {
+          name
+        }
+      }
+    """
+
+    val expected =
+      Select("character", List(Binding("id", StringValue("1000"))),
+        Select("name", Nil)
+      )
+
+    val res = QueryParser.parseText(text)
+    assert(res == Ior.Right(UntypedSubscription(expected, Nil)))
   }
 
   test("simple nested query") {
@@ -54,7 +94,7 @@ final class CompilerSuite extends CatsSuite {
       )
 
     val res = QueryParser.parseText(text)
-    assert(res == Ior.Right((expected, Nil)))
+    assert(res == Ior.Right(UntypedQuery(expected, Nil)))
   }
 
   test("shorthand query") {
@@ -85,7 +125,7 @@ final class CompilerSuite extends CatsSuite {
       )
 
     val res = QueryParser.parseText(text)
-    assert(res == Ior.Right((expected, Nil)))
+    assert(res == Ior.Right(UntypedQuery(expected, Nil)))
   }
 
   test("field alias") {
@@ -111,7 +151,7 @@ final class CompilerSuite extends CatsSuite {
       )
 
     val res = QueryParser.parseText(text)
-    assert(res == Ior.Right((expected, Nil)))
+    assert(res == Ior.Right(UntypedQuery(expected, Nil)))
   }
 
   test("introspection query") {
@@ -140,7 +180,7 @@ final class CompilerSuite extends CatsSuite {
       )
 
     val res = QueryParser.parseText(text)
-    assert(res == Ior.Right((expected, Nil)))
+    assert(res == Ior.Right(UntypedQuery(expected, Nil)))
   }
 
   test("simple selector elaborated query") {


### PR DESCRIPTION
* Introduced `UntypedOperation`, which can be `UntypedQuery`, `UntypedMutation` or `UntypedSubscription` and contains a `Query` and `UntypedVarDefs`.
* `QueryParser`'s `parse*` methods that returned tuples now return an `UntypedOperation`.