### PR TITLE
fix ci to fetch tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v7
       - uses: olafurpg/setup-gpg@v2
       - name: Publish


### PR DESCRIPTION
`actions/checkout@v2` does not fetch tags, but it will if you set `fetch-depth` to zero. Snapshot versions should be correct now, fingers crossed.