### PR TITLE
Add tests for deprecated annotation failure modes

### DIFF
--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -98,7 +98,7 @@ final class SchemaSpec extends CatsSuite {
     val schema = Schema(
       """
          type ExampleType {
-          oldField: String @deprecated(notareadon: "foo bar baz")
+          oldField: String @deprecated(notareason: "foo bar baz")
         }
     """
     )

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -77,4 +77,35 @@ final class SchemaSpec extends CatsSuite {
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
+
+  test("schema validation: multiple deprecated annotations") {
+    val schema = Schema(
+      """
+         type ExampleType {
+          oldField: String @deprecated @deprecated
+        }
+    """
+    )
+
+    schema match {
+      case Ior.Left(e) => assert(e.head.\\("message").head.asString.get == "Only a single deprecated allowed at a given location")
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+
+  test("schema validation: deprecated annotation with unsupported argument") {
+    val schema = Schema(
+      """
+         type ExampleType {
+          oldField: String @deprecated(notareadon: "foo bar baz")
+        }
+    """
+    )
+
+    schema match {
+      case Ior.Left(e) => assert(e.head.\\("message").head.asString.get == "deprecated must have a single String 'reason' argument, or no arguments")
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
 }


### PR DESCRIPTION
Not sure if this was the sort of thing you had in mind for https://github.com/gemini-hlsw/gsp-graphql/issues/25 ?