### PR TITLE
Validate interface implementation

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -955,11 +955,11 @@ object SchemaValidator {
   }
 
   def validateImpls(definitions: List[TypeDefinition]): List[Json] = {
-    val interfaces = definitions.collect[InterfaceTypeDefinition] {
+    val interfaces = definitions.collect {
       case a: InterfaceTypeDefinition => a
     }
 
-    val objects = definitions.collect[ObjectTypeDefinition] {
+    val objects = definitions.collect {
       case a: ObjectTypeDefinition => a
     }
 

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -138,7 +138,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Interface Character implemented by type Human is not defined", "Interface Contactable implemented by type Human is not defined"))
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Interface Character implemented by object Human is not defined", "Interface Contactable implemented by object Human is not defined"))
         assert(b.types.map(_.name) == List("Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -161,7 +161,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by type Human", "Expected field email from interface Character is not implemented by type Human"))
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by object Human", "Expected field email from interface Character is not implemented by object Human"))
         assert(b.types.map(_.name) == List("Character", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -182,7 +182,28 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field name from interface Character is not implemented by type Human"))
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Field name has type Int!, however implemented interface Character requires it to be of type String!"))
+        assert(b.types.map(_.name) == List("Character", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: object implementing interface field with mismatched arguments") {
+    val schema = Schema(
+      """
+         interface Character {
+          name(foo: Int!): String!
+        }
+
+         type Human implements Character {
+           name(foo: String!): String!
+         }
+    """
+    )
+
+    schema match {
+      case Both(a, b)  =>
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Field name of object Human has has an argument list that does not match that specified by implemented interface Character"))
         assert(b.types.map(_.name) == List("Character", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -208,7 +229,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by type Human", "Expected field id from interface Character is not implemented by type Dog"))
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by object Human", "Expected field id from interface Character is not implemented by object Dog"))
         assert(b.types.map(_.name) == List("Character", "Human", "Dog"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -234,13 +255,12 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by type Human", "Expected field email from interface Contactable is not implemented by type Human"))
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by object Human", "Expected field email from interface Contactable is not implemented by object Human"))
         assert(b.types.map(_.name) == List("Character", "Contactable", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
 
-  //FIXME reformat examples
   test("schema validation: object correctly implements transitive interface") {
     val schema = Schema(
       """
@@ -265,11 +285,4 @@ final class SchemaSpec extends CatsSuite {
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
-
-  //FIXME what about when names the same but types differ? arg types differ?
-
-
-  //Out of scope
-  //FIXME add empty interfaces test, another PR?
-  //FIXME check that object implements transative interface
 }

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -3,7 +3,7 @@
 
 package schema
 
-import cats.data.Ior
+import cats.data.{Ior, NonEmptyChain}
 import cats.data.Ior.Both
 import cats.tests.CatsSuite
 import edu.gemini.grackle.Schema
@@ -126,4 +126,150 @@ final class SchemaSpec extends CatsSuite {
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
+
+  test("schema validation: object implementing unspecified interfaces") {
+    val schema = Schema(
+      """
+         type Human implements Character & Contactable {
+           name: String!
+         }
+    """
+    )
+
+    schema match {
+      case Both(a, b)  =>
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Interface Character implemented by type Human is not defined", "Interface Contactable implemented by type Human is not defined"))
+        assert(b.types.map(_.name) == List("Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: object failing to implement interface fields") {
+    val schema = Schema(
+      """
+         interface Character {
+          id: ID!
+          name: String!
+          email: String!
+        }
+
+         type Human implements Character {
+           name: String!
+         }
+    """
+    )
+
+    schema match {
+      case Both(a, b)  =>
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by type Human", "Expected field email from interface Character is not implemented by type Human"))
+        assert(b.types.map(_.name) == List("Character", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: object implementing interface field with wrong type") {
+    val schema = Schema(
+      """
+         interface Character {
+          name: String!
+        }
+
+         type Human implements Character {
+           name: Int!
+         }
+    """
+    )
+
+    schema match {
+      case Both(a, b)  =>
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field name from interface Character is not implemented by type Human"))
+        assert(b.types.map(_.name) == List("Character", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: multiple objects failing to implement interface field") {
+    val schema = Schema(
+      """
+         interface Character {
+          id: ID!
+          name: String!
+        }
+
+         type Human implements Character {
+           name: String!
+         }
+
+         type Dog implements Character {
+           name: String!
+         }
+    """
+    )
+
+    schema match {
+      case Both(a, b)  =>
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by type Human", "Expected field id from interface Character is not implemented by type Dog"))
+        assert(b.types.map(_.name) == List("Character", "Human", "Dog"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: object failing to implement multiple interface fields") {
+    val schema = Schema(
+      """
+         interface Character {
+          id: ID!
+          name: String!
+        }
+
+        interface Contactable {
+          email: String!
+        }
+
+         type Human implements Character & Contactable {
+           name: String!
+         }
+    """
+    )
+
+    schema match {
+      case Both(a, b)  =>
+        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by type Human", "Expected field email from interface Contactable is not implemented by type Human"))
+        assert(b.types.map(_.name) == List("Character", "Contactable", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  //FIXME reformat examples
+  test("schema validation: object correctly implements transitive interface") {
+    val schema = Schema(
+      """
+         interface Node {
+            id: ID!
+          }
+
+          interface Resource implements Node {
+            id: ID!
+            url: String
+          }
+
+         type Human implements Resource & Node {
+            id: ID!
+            url: String
+         }
+    """
+    )
+
+    schema match {
+      case Ior.Right(a) => assert(a.types.map(_.name) == List("Node", "Resource", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  //FIXME what about when names the same but types differ? arg types differ?
+
+
+  //Out of scope
+  //FIXME add empty interfaces test, another PR?
+  //FIXME check that object implements transative interface
 }


### PR DESCRIPTION
Validates that an object correctly implements any specified interfaces per #68.

Does not include checking that an interface correctly implements another, nor that an object implements all transitive interfaces.

Feedback appreciated :)
