### PR TITLE
fix interpretation of schema definition, select correct root type

### DIFF
--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -29,10 +29,13 @@ abstract class Mapping[F[_]](implicit val M: Monad[F]) extends QueryExecutor[F, 
   def run(query: Query, rootTpe: Type): F[Json] =
     interpreter.run(query, rootTpe)
 
+  def run(op: Operation): F[Json] =
+    run(op.query, op.rootTpe)
+
   def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): F[Json] =
     compiler.compile(text, name, untypedEnv, useIntrospection) match {
-      case Ior.Right(compiledQuery) =>
-        run(compiledQuery, schema.queryType)
+      case Ior.Right(operation) =>
+        run(operation.query, schema.queryType)
       case invalid =>
         QueryInterpreter.mkInvalidResponse(invalid).pure[F]
     }

--- a/modules/core/src/main/scala/operation.scala
+++ b/modules/core/src/main/scala/operation.scala
@@ -3,14 +3,27 @@
 
 package edu.gemini.grackle
 
+import cats.data.NonEmptyChain
+import cats.syntax.all._
+import io.circe.literal.JsonStringContext
+
 import Query._
 
 sealed trait UntypedOperation {
   val query: Query
   val variables: UntypedVarDefs
+  def rootTpe(schema: Schema): Result[NamedType] =
+    this match {
+      case UntypedOperation.UntypedQuery(_, _)        => schema.queryType.rightIor
+      case UntypedOperation.UntypedMutation(_, _)     => schema.mutationType.toRight(NonEmptyChain.one(json"""{"message": "No mutation type defined in this schema."}""")).toIor
+      case UntypedOperation.UntypedSubscription(_, _) => schema.subscriptionType.toRight(NonEmptyChain.one(json"""{"message": "No subscription type defined in this schema."}""")).toIor
+    }
 }
 object UntypedOperation {
   case class UntypedQuery(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
   case class UntypedMutation(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
   case class UntypedSubscription(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
 }
+
+case class Operation(query: Query, rootTpe: NamedType)
+

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -1133,7 +1133,7 @@ object QueryInterpreter {
    *  Construct a GraphQL error response from a `Result`, ignoring any
    *  right hand side in `result`.
    */
-  def mkInvalidResponse(result: Result[Query]): Json =
+  def mkInvalidResponse(result: Result[Operation]): Json =
     mkResponse(None, result.left.map(_.toList).getOrElse(Nil))
 
   /** Construct a GraphQL error object */

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -12,6 +12,7 @@ import io.circe.literal.JsonStringContext
 import edu.gemini.grackle._
 import Query._, Predicate._, Value._, UntypedOperation._
 import QueryCompiler._, ComponentElaborator.TrivialJoin
+import edu.gemini.grackle.Operation
 
 final class CompilerSuite extends CatsSuite {
   test("simple query") {
@@ -197,16 +198,19 @@ final class CompilerSuite extends CatsSuite {
     """
 
     val expected =
-      Select(
-        "character", Nil,
-        Unique(Eql(FieldPath(List("id")), Const("1000")),
-          Select("name", Nil) ~
-            Select(
-              "friends", Nil,
-              Select("name", Nil)
-            )
-        )
-    )
+      Operation(
+        Select(
+          "character", Nil,
+          Unique(Eql(FieldPath(List("id")), Const("1000")),
+            Select("name", Nil) ~
+              Select(
+                "friends", Nil,
+                Select("name", Nil)
+              )
+          )
+       ),
+       AtomicMapping.schema.queryType
+      )
 
     val res = AtomicMapping.compiler.compile(query)
 
@@ -316,20 +320,22 @@ final class CompilerSuite extends CatsSuite {
     """
 
     val expected =
-      Wrap("componenta",
-        Component(ComponentA, TrivialJoin,
-          Select("componenta", Nil,
-            Select("fielda1", Nil) ~
-            Select("fielda2", Nil,
-              Wrap("componentb",
-                Component(ComponentB, TrivialJoin,
-                  Select("componentb", Nil,
-                    Select("fieldb1", Nil) ~
-                    Select("fieldb2", Nil,
-                      Wrap("componentc",
-                        Component(ComponentC, TrivialJoin,
-                          Select("componentc", Nil,
-                            Select("fieldc1", Nil)
+      Operation(
+        Wrap("componenta",
+          Component(ComponentA, TrivialJoin,
+            Select("componenta", Nil,
+              Select("fielda1", Nil) ~
+              Select("fielda2", Nil,
+                Wrap("componentb",
+                  Component(ComponentB, TrivialJoin,
+                    Select("componentb", Nil,
+                      Select("fieldb1", Nil) ~
+                      Select("fieldb2", Nil,
+                        Wrap("componentc",
+                          Component(ComponentC, TrivialJoin,
+                            Select("componentc", Nil,
+                              Select("fieldc1", Nil)
+                            )
                           )
                         )
                       )
@@ -339,7 +345,8 @@ final class CompilerSuite extends CatsSuite {
               )
             )
           )
-        )
+        ),
+        ComposedMapping.schema.queryType
       )
 
     val res = ComposedMapping.compiler.compile(query)

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -12,6 +12,7 @@ import io.circe.literal.JsonStringContext
 import edu.gemini.grackle._
 import Query._, Predicate._, Value._
 import QueryCompiler._
+import edu.gemini.grackle.Operation
 
 final class FragmentSuite extends CatsSuite {
   test("simple fragment query") {
@@ -35,25 +36,28 @@ final class FragmentSuite extends CatsSuite {
     """
 
     val expected =
-      Select("user", Nil,
-        Unique(Eql(FieldPath(List("id")), Const("1")),
-          Group(List(
-            Select("friends", Nil,
-              Group(List(
-                Select("id", Nil, Empty),
-                Select("name", Nil, Empty),
-                Select("profilePic", Nil, Empty)
-              ))
-            ),
-            Select("mutualFriends", Nil,
-              Group(List(
-                Select("id", Nil, Empty),
-                Select("name", Nil, Empty),
-                Select("profilePic", Nil, Empty)
-              ))
-            )
-          ))
-        )
+      Operation(
+        Select("user", Nil,
+          Unique(Eql(FieldPath(List("id")), Const("1")),
+            Group(List(
+              Select("friends", Nil,
+                Group(List(
+                  Select("id", Nil, Empty),
+                  Select("name", Nil, Empty),
+                  Select("profilePic", Nil, Empty)
+                ))
+              ),
+              Select("mutualFriends", Nil,
+                Group(List(
+                  Select("id", Nil, Empty),
+                  Select("name", Nil, Empty),
+                  Select("profilePic", Nil, Empty)
+                ))
+              )
+            ))
+          )
+      ),
+      FragmentMapping.schema.queryType
     )
 
     val expectedResult = json"""
@@ -93,7 +97,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -123,25 +127,28 @@ final class FragmentSuite extends CatsSuite {
     """
 
     val expected =
-      Select("user", Nil,
-        Unique(Eql(FieldPath(List("id")), Const("1")),
-          Group(List(
-            Select("friends", Nil,
-              Group(List(
-                Select("id", Nil, Empty),
-                Select("name", Nil, Empty),
-                Select("profilePic", Nil, Empty)
-              ))
-            ),
-            Select("mutualFriends", Nil,
-              Group(List(
-                Select("id", Nil, Empty),
-                Select("name", Nil, Empty),
-                Select("profilePic", Nil, Empty)
-              ))
-            )
-          ))
-        )
+      Operation(
+        Select("user", Nil,
+          Unique(Eql(FieldPath(List("id")), Const("1")),
+            Group(List(
+              Select("friends", Nil,
+                Group(List(
+                  Select("id", Nil, Empty),
+                  Select("name", Nil, Empty),
+                  Select("profilePic", Nil, Empty)
+                ))
+              ),
+              Select("mutualFriends", Nil,
+                Group(List(
+                  Select("id", Nil, Empty),
+                  Select("name", Nil, Empty),
+                  Select("profilePic", Nil, Empty)
+                ))
+              )
+            ))
+          )
+        ),
+        FragmentMapping.schema.queryType
       )
 
     val expectedResult = json"""
@@ -181,7 +188,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -210,14 +217,17 @@ final class FragmentSuite extends CatsSuite {
     val Page = FragmentMapping.schema.ref("Page")
 
     val expected =
-      Select("profiles",
-        Nil,
-        Group(List(
-          Select("id", Nil, Empty),
-          Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
-          Narrow(User, Select("name", Nil, Empty)),
-          Narrow(Page, Select("title", Nil, Empty))
-        ))
+      Operation(
+        Select("profiles",
+          Nil,
+          Group(List(
+            Select("id", Nil, Empty),
+            Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
+            Narrow(User, Select("name", Nil, Empty)),
+            Narrow(Page, Select("title", Nil, Empty))
+          ))
+        ),
+        FragmentMapping.schema.queryType
       )
 
     val expectedResult = json"""
@@ -258,7 +268,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -282,12 +292,15 @@ final class FragmentSuite extends CatsSuite {
     val Page = FragmentMapping.schema.ref("Page")
 
     val expected =
-      Select("profiles", Nil,
-        Group(List(
-          Select("id", Nil, Empty),
-          Narrow(User, Select("name", Nil, Empty)),
-          Narrow(Page, Select("title", Nil, Empty))
-        ))
+      Operation(
+        Select("profiles", Nil,
+          Group(List(
+            Select("id", Nil, Empty),
+            Narrow(User, Select("name", Nil, Empty)),
+            Narrow(Page, Select("title", Nil, Empty))
+          ))
+        ),
+        FragmentMapping.schema.queryType
       )
 
     val expectedResult = json"""
@@ -323,7 +336,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -362,41 +375,44 @@ final class FragmentSuite extends CatsSuite {
     val Page = FragmentMapping.schema.ref("Page")
 
     val expected =
-      Group(List(
-        Select("user", Nil,
-          Unique(Eql(FieldPath(List("id")), Const("1")),
-            Select("favourite", Nil,
-              Group(List(
-                Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
+      Operation(
+        Group(List(
+          Select("user", Nil,
+            Unique(Eql(FieldPath(List("id")), Const("1")),
+              Select("favourite", Nil,
                 Group(List(
-                  Narrow(User, Select("id", Nil, Empty)),
-                  Narrow(User, Select("name", Nil, Empty)))),
-                Group(List(
-                  Narrow(Page, Select("id", Nil, Empty)),
-                  Narrow(Page, Select("title", Nil, Empty))
+                  Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
+                  Group(List(
+                    Narrow(User, Select("id", Nil, Empty)),
+                    Narrow(User, Select("name", Nil, Empty)))),
+                  Group(List(
+                    Narrow(Page, Select("id", Nil, Empty)),
+                    Narrow(Page, Select("title", Nil, Empty))
+                  ))
                 ))
-              ))
+              )
             )
-          )
-        ),
-        Rename("page", Select("user", Nil,
-          Unique(Eql(FieldPath(List("id")), Const("2")),
-            Select("favourite", Nil,
-              Group(List(
-                Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
+          ),
+          Rename("page", Select("user", Nil,
+            Unique(Eql(FieldPath(List("id")), Const("2")),
+              Select("favourite", Nil,
                 Group(List(
-                  Narrow(User, Select("id", Nil, Empty)),
-                  Narrow(User, Select("name", Nil, Empty))
-                )),
-                Group(List(
-                  Narrow(Page, Select("id", Nil, Empty)),
-                  Narrow(Page, Select("title", Nil, Empty))
+                  Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
+                  Group(List(
+                    Narrow(User, Select("id", Nil, Empty)),
+                    Narrow(User, Select("name", Nil, Empty))
+                  )),
+                  Group(List(
+                    Narrow(Page, Select("id", Nil, Empty)),
+                    Narrow(Page, Select("title", Nil, Empty))
+                  ))
                 ))
-              ))
+              )
             )
-          )
-        ))
-      ))
+          ))
+        )),
+        FragmentMapping.schema.queryType
+      )
 
     val expectedResult = json"""
       {
@@ -423,7 +439,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -10,6 +10,7 @@ import cats.tests.CatsSuite
 import edu.gemini.grackle._
 import Query._, Value._
 import QueryCompiler._
+import edu.gemini.grackle.Operation
 
 final class InputValuesSuite extends CatsSuite {
   test("null value") {
@@ -28,11 +29,14 @@ final class InputValuesSuite extends CatsSuite {
     """
 
     val expected =
-      Group(List(
-        Select("field", List(Binding("arg", AbsentValue)), Select("subfield", Nil, Empty)),
-        Select("field", List(Binding("arg", NullValue)), Select("subfield", Nil, Empty)),
-        Select("field", List(Binding("arg", IntValue(23))), Select("subfield", Nil, Empty))
-      ))
+      Operation(
+        Group(List(
+          Select("field", List(Binding("arg", AbsentValue)), Select("subfield", Nil, Empty)),
+          Select("field", List(Binding("arg", NullValue)), Select("subfield", Nil, Empty)),
+          Select("field", List(Binding("arg", IntValue(23))), Select("subfield", Nil, Empty))
+        )),
+        InputValuesMapping.schema.queryType
+      )
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
@@ -52,14 +56,17 @@ final class InputValuesSuite extends CatsSuite {
     """
 
     val expected =
-      Group(List(
-        Select("listField", List(Binding("arg", ListValue(Nil))),
-          Select("subfield", Nil, Empty)
-        ),
-        Select("listField", List(Binding("arg", ListValue(List(StringValue("foo"),  StringValue("bar"))))),
-          Select("subfield", Nil, Empty)
-        )
-      ))
+      Operation(
+        Group(List(
+          Select("listField", List(Binding("arg", ListValue(Nil))),
+            Select("subfield", Nil, Empty)
+          ),
+          Select("listField", List(Binding("arg", ListValue(List(StringValue("foo"),  StringValue("bar"))))),
+            Select("subfield", Nil, Empty)
+          )
+        )),
+        InputValuesMapping.schema.queryType
+      )
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
@@ -76,17 +83,20 @@ final class InputValuesSuite extends CatsSuite {
     """
 
     val expected =
-      Select("objectField",
-        List(Binding("arg",
-          ObjectValue(List(
-            ("foo", IntValue(23)),
-            ("bar", BooleanValue(true)),
-            ("baz", StringValue("quux")),
-            ("defaulted", StringValue("quux")),
-            ("nullable", AbsentValue)
-          ))
-        )),
-        Select("subfield", Nil, Empty)
+      Operation(
+        Select("objectField",
+          List(Binding("arg",
+            ObjectValue(List(
+              ("foo", IntValue(23)),
+              ("bar", BooleanValue(true)),
+              ("baz", StringValue("quux")),
+              ("defaulted", StringValue("quux")),
+              ("nullable", AbsentValue)
+            ))
+          )),
+          Select("subfield", Nil, Empty)
+        ),
+        InputValuesMapping.schema.queryType
       )
 
     val compiled = InputValuesMapping.compiler.compile(query, None)

--- a/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
@@ -10,6 +10,7 @@ import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
 import Query._
+import edu.gemini.grackle.Operation
 
 final class SkipIncludeSuite extends CatsSuite {
   test("skip/include field") {
@@ -38,10 +39,13 @@ final class SkipIncludeSuite extends CatsSuite {
     """
 
     val expected =
-      Group(List(
-        Rename("b", Select("field", Nil, Select("subfieldB", Nil, Empty))),
-        Rename("c", Select("field", Nil, Select("subfieldA", Nil, Empty)))
-      ))
+      Operation(
+        Group(List(
+          Rename("b", Select("field", Nil, Select("subfieldB", Nil, Empty))),
+          Rename("c", Select("field", Nil, Select("subfieldA", Nil, Empty)))
+        )),
+        SkipIncludeMapping.schema.queryType
+      )
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
@@ -80,26 +84,29 @@ final class SkipIncludeSuite extends CatsSuite {
     """
 
     val expected =
-      Group(List(
-        Rename("a", Select("field", Nil, Empty)),
-        Rename("b",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
-        ),
-        Rename("c",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
-        ),
-        Rename("d", Select("field", Nil, Empty))
-      ))
+      Operation(
+        Group(List(
+          Rename("a", Select("field", Nil, Empty)),
+          Rename("b",
+            Select("field", Nil,
+              Group(List(
+                Select("subfieldA", Nil, Empty),
+                Select("subfieldB", Nil, Empty)
+              ))
+            )
+          ),
+          Rename("c",
+            Select("field", Nil,
+              Group(List(
+                Select("subfieldA", Nil, Empty),
+                Select("subfieldB", Nil, Empty)
+              ))
+            )
+          ),
+          Rename("d", Select("field", Nil, Empty))
+        )),
+        SkipIncludeMapping.schema.queryType
+      )
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
@@ -131,11 +138,14 @@ final class SkipIncludeSuite extends CatsSuite {
     """
 
     val expected =
-      Select("field", Nil,
-        Group(List(
-          Rename("b", Select("subfieldB", Nil, Empty)),
-          Rename("c", Select("subfieldA", Nil, Empty))
-        ))
+      Operation(
+        Select("field", Nil,
+          Group(List(
+            Rename("b", Select("subfieldB", Nil, Empty)),
+            Rename("c", Select("subfieldA", Nil, Empty))
+          ))
+        ),
+        SkipIncludeMapping.schema.queryType
       )
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
@@ -182,26 +192,29 @@ final class SkipIncludeSuite extends CatsSuite {
     """
 
     val expected =
-      Group(List(
-        Rename("a", Select("field", Nil, Empty)),
-        Rename("b",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
-        ),
-        Rename("c",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
-        ),
-        Rename("d", Select("field", Nil, Empty))
-      ))
+      Operation(
+        Group(List(
+          Rename("a", Select("field", Nil, Empty)),
+          Rename("b",
+            Select("field", Nil,
+              Group(List(
+                Select("subfieldA", Nil, Empty),
+                Select("subfieldB", Nil, Empty)
+              ))
+            )
+          ),
+          Rename("c",
+            Select("field", Nil,
+              Group(List(
+                Select("subfieldA", Nil, Empty),
+                Select("subfieldB", Nil, Empty)
+              ))
+            )
+          ),
+          Rename("d", Select("field", Nil, Empty))
+        )),
+        SkipIncludeMapping.schema.queryType
+      )
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
@@ -231,11 +244,14 @@ final class SkipIncludeSuite extends CatsSuite {
     """
 
     val expected =
-      Select("field", Nil,
-        Group(List(
-          Rename("b", Select("subfieldB", Nil, Empty)),
-          Rename("c", Select("subfieldA", Nil, Empty))
-        ))
+      Operation(
+        Select("field", Nil,
+          Group(List(
+            Rename("b", Select("subfieldB", Nil, Empty)),
+            Rename("c", Select("subfieldA", Nil, Empty))
+          ))
+        ),
+        SkipIncludeMapping.schema.queryType
       )
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -11,6 +11,7 @@ import io.circe.literal.JsonStringContext
 import edu.gemini.grackle._
 import Query._, Value._
 import QueryCompiler._
+import edu.gemini.grackle.Operation
 
 final class VariablesSuite extends CatsSuite {
   test("simple variables query") {
@@ -31,12 +32,15 @@ final class VariablesSuite extends CatsSuite {
     """
 
     val expected =
-      Select("user", List(Binding("id", IDValue("4"))),
-        Group(List(
-          Select("id", Nil, Empty),
-          Select("name", Nil, Empty),
-          Select("profilePic", List(Binding("size", IntValue(60))), Empty)
-        ))
+      Operation(
+        Select("user", List(Binding("id", IDValue("4"))),
+          Group(List(
+            Select("id", Nil, Empty),
+            Select("name", Nil, Empty),
+            Select("profilePic", List(Binding("size", IntValue(60))), Empty)
+          ))
+        ),
+        VariablesMapping.schema.queryType
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
@@ -60,9 +64,12 @@ final class VariablesSuite extends CatsSuite {
     """
 
     val expected =
-      Select("users",
-        List(Binding("ids", ListValue(List(IDValue("1"), IDValue("2"), IDValue("3"))))),
-        Select("name", Nil, Empty)
+      Operation(
+        Select("users",
+          List(Binding("ids", ListValue(List(IDValue("1"), IDValue("2"), IDValue("3"))))),
+          Select("name", Nil, Empty)
+        ),
+        VariablesMapping.schema.queryType
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
@@ -91,18 +98,21 @@ final class VariablesSuite extends CatsSuite {
     """
 
     val expected =
-      Select("search",
-        List(Binding("pattern",
-          ObjectValue(List(
-            ("name", StringValue("Foo")),
-            ("age", IntValue(23)),
-            ("id", IDValue("123"))
+      Operation(
+        Select("search",
+          List(Binding("pattern",
+            ObjectValue(List(
+              ("name", StringValue("Foo")),
+              ("age", IntValue(23)),
+              ("id", IDValue("123"))
+            ))
+          )),
+          Group(List(
+            Select("name", Nil, Empty),
+            Select("id", Nil, Empty)
           ))
-        )),
-        Group(List(
-          Select("name", Nil, Empty),
-          Select("id", Nil, Empty)
-        ))
+        ),
+        VariablesMapping.schema.queryType
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -308,4 +308,91 @@ final class SchemaSpec extends CatsSuite {
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
+
+  test("explicit Schema type (complete)") {
+
+    val schema =
+      Schema("""
+
+        schema {
+          query: MyQuery
+          mutation: MyMutation
+          subscription: MySubscription
+        }
+
+        type MyQuery {
+          foo: Int
+        }
+
+        type MyMutation {
+          setFoo(n: Int): Int
+        }
+
+        type MySubscription {
+          watchFoo: Int
+        }
+
+      """).right.get
+
+    assert(schema.queryType                 =:= schema.ref("MyQuery"))
+    assert(schema.mutationType.exists(_     =:= schema.ref("MyMutation")))
+    assert(schema.subscriptionType.exists(_ =:= schema.ref("MySubscription")))
+
+  }
+
+  test("explicit Schema type (partial)") {
+
+    val schema =
+      Schema("""
+
+        schema {
+          query: MyQuery
+          mutation: MyMutation
+        }
+
+        type MyQuery {
+          foo: Int
+        }
+
+        type MyMutation {
+          setFoo(n: Int): Int
+        }
+
+      """).right.get
+
+    assert(schema.queryType             =:= schema.ref("MyQuery"))
+    assert(schema.mutationType.exists(_ =:= schema.ref("MyMutation")))
+    assert(schema.subscriptionType       == None)
+
+  }
+
+  test("implicit Schema type") {
+
+    val schema =
+      Schema("""
+
+        type Query {
+          foo: Int
+        }
+
+        type Mutation {
+          setFoo(n: Int): Int
+        }
+
+        type Subscription {
+          watchFoo: Int
+        }
+
+      """).right.get
+
+    assert(schema.queryType                 =:= schema.ref("Query"))
+    assert(schema.mutationType.exists(_     =:= schema.ref("Mutation")))
+    assert(schema.subscriptionType.exists(_ =:= schema.ref("Subscription")))
+
+  }
+
+  ignore("no query type (crashes)") {
+    Schema("scalar Foo").right.get.queryType
+  }
+
 }


### PR DESCRIPTION
This changes `QueryCompiler.compile` to return `Result[Operation]` where `Operation(query: Query, rootTpe: Type)` which includes the selected root type. `QueryExecutor` uses this by default when invoking the interpreter (it had been using `schema.queryType` in all cases). 

`Operation` is a bit overloaded so maybe `RootedQuery` or something would be a better name.

This fixes a few problems:

- It was not possible to declare `schema { ... }` because it was expecting `NamedType` fields but they're actually `NullableTyped(NamedType)` as parsed.
- In the absence of a `schema { ... }` declaration we were defaulting to `schema { query: Query }` which ignored `type Mutation` and `type Subscription` when present. We now delegate to the [correct] superclass behavior in this case.
