### PR TITLE
fix interpretation of schema definition, select correct root type

### DIFF
--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -29,10 +29,13 @@ abstract class Mapping[F[_]](implicit val M: Monad[F]) extends QueryExecutor[F, 
   def run(query: Query, rootTpe: Type): F[Json] =
     interpreter.run(query, rootTpe)
 
+  def run(op: Operation): F[Json] =
+    run(op.query, op.rootTpe)
+
   def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): F[Json] =
     compiler.compile(text, name, untypedEnv, useIntrospection) match {
-      case Ior.Right(compiledQuery) =>
-        run(compiledQuery, schema.queryType)
+      case Ior.Right(operation) =>
+        run(operation.query, schema.queryType)
       case invalid =>
         QueryInterpreter.mkInvalidResponse(invalid).pure[F]
     }

--- a/modules/core/src/main/scala/operation.scala
+++ b/modules/core/src/main/scala/operation.scala
@@ -3,14 +3,27 @@
 
 package edu.gemini.grackle
 
+import cats.data.NonEmptyChain
+import cats.syntax.all._
+import io.circe.literal.JsonStringContext
+
 import Query._
 
 sealed trait UntypedOperation {
   val query: Query
   val variables: UntypedVarDefs
+  def rootTpe(schema: Schema): Result[NamedType] =
+    this match {
+      case UntypedOperation.UntypedQuery(_, _)        => schema.queryType.rightIor
+      case UntypedOperation.UntypedMutation(_, _)     => schema.mutationType.toRight(NonEmptyChain.one(json"""{"message": "No mutation type defined in this schema."}""")).toIor
+      case UntypedOperation.UntypedSubscription(_, _) => schema.subscriptionType.toRight(NonEmptyChain.one(json"""{"message": "No subscription type defined in this schema."}""")).toIor
+    }
 }
 object UntypedOperation {
   case class UntypedQuery(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
   case class UntypedMutation(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
   case class UntypedSubscription(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
 }
+
+case class Operation(query: Query, rootTpe: NamedType)
+

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -1133,7 +1133,7 @@ object QueryInterpreter {
    *  Construct a GraphQL error response from a `Result`, ignoring any
    *  right hand side in `result`.
    */
-  def mkInvalidResponse(result: Result[Query]): Json =
+  def mkInvalidResponse(result: Result[Operation]): Json =
     mkResponse(None, result.left.map(_.toList).getOrElse(Nil))
 
   /** Construct a GraphQL error object */

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -210,7 +210,7 @@ final class CompilerSuite extends CatsSuite {
 
     val res = AtomicMapping.compiler.compile(query)
 
-    assert(res == Ior.Right(expected))
+    assert(res.map(_.query) == Ior.Right(expected))
   }
 
   test("invalid: object subselection set empty") {
@@ -344,7 +344,7 @@ final class CompilerSuite extends CatsSuite {
 
     val res = ComposedMapping.compiler.compile(query)
 
-    assert(res == Ior.Right(expected))
+    assert(res.map(_.query) == Ior.Right(expected))
   }
 }
 

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -91,9 +91,9 @@ final class FragmentSuite extends CatsSuite {
 
     val compiled = FragmentMapping.compiler.compile(query)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -179,9 +179,9 @@ final class FragmentSuite extends CatsSuite {
 
     val compiled = FragmentMapping.compiler.compile(query)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -256,9 +256,9 @@ final class FragmentSuite extends CatsSuite {
 
     val compiled = FragmentMapping.compiler.compile(query)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -321,9 +321,9 @@ final class FragmentSuite extends CatsSuite {
 
     val compiled = FragmentMapping.compiler.compile(query)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }
@@ -421,9 +421,9 @@ final class FragmentSuite extends CatsSuite {
 
     val compiled = FragmentMapping.compiler.compile(query)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get)
     //println(res)
     assert(res == expectedResult)
   }

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -36,7 +36,7 @@ final class InputValuesSuite extends CatsSuite {
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("list value") {
@@ -63,7 +63,7 @@ final class InputValuesSuite extends CatsSuite {
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("input object value") {
@@ -91,7 +91,7 @@ final class InputValuesSuite extends CatsSuite {
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 }
 

--- a/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
@@ -46,7 +46,7 @@ final class SkipIncludeSuite extends CatsSuite {
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("skip/include fragment spread") {
@@ -104,7 +104,7 @@ final class SkipIncludeSuite extends CatsSuite {
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("fragment spread with nested skip/include") {
@@ -141,7 +141,7 @@ final class SkipIncludeSuite extends CatsSuite {
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("skip/include inline fragment") {
@@ -206,7 +206,7 @@ final class SkipIncludeSuite extends CatsSuite {
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("inline fragment with nested skip/include") {
@@ -241,7 +241,7 @@ final class SkipIncludeSuite extends CatsSuite {
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
 
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 }
 

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -41,7 +41,7 @@ final class VariablesSuite extends CatsSuite {
 
     val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("list variable query") {
@@ -67,7 +67,7 @@ final class VariablesSuite extends CatsSuite {
 
     val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 
   test("object variable query") {
@@ -107,7 +107,7 @@ final class VariablesSuite extends CatsSuite {
 
     val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
-    assert(compiled == Ior.Right(expected))
+    assert(compiled.map(_.query) == Ior.Right(expected))
   }
 }
 

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -308,4 +308,91 @@ final class SchemaSpec extends CatsSuite {
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
+
+  test("explicit Schema type (complete)") {
+
+    val schema =
+      Schema("""
+
+        schema {
+          query: MyQuery
+          mutation: MyMutation
+          subscription: MySubscription
+        }
+
+        type MyQuery {
+          foo: Int
+        }
+
+        type MyMutation {
+          setFoo(n: Int): Int
+        }
+
+        type MySubscription {
+          watchFoo: Int
+        }
+
+      """).right.get
+
+    assert(schema.queryType                 =:= schema.ref("MyQuery"))
+    assert(schema.mutationType.exists(_     =:= schema.ref("MyMutation")))
+    assert(schema.subscriptionType.exists(_ =:= schema.ref("MySubscription")))
+
+  }
+
+  test("explicit Schema type (partial)") {
+
+    val schema =
+      Schema("""
+
+        schema {
+          query: MyQuery
+          mutation: MyMutation
+        }
+
+        type MyQuery {
+          foo: Int
+        }
+
+        type MyMutation {
+          setFoo(n: Int): Int
+        }
+
+      """).right.get
+
+    assert(schema.queryType             =:= schema.ref("MyQuery"))
+    assert(schema.mutationType.exists(_ =:= schema.ref("MyMutation")))
+    assert(schema.subscriptionType       == None)
+
+  }
+
+  test("implicit Schema type") {
+
+    val schema =
+      Schema("""
+
+        type Query {
+          foo: Int
+        }
+
+        type Mutation {
+          setFoo(n: Int): Int
+        }
+
+        type Subscription {
+          watchFoo: Int
+        }
+
+      """).right.get
+
+    assert(schema.queryType                 =:= schema.ref("Query"))
+    assert(schema.mutationType.exists(_     =:= schema.ref("Mutation")))
+    assert(schema.subscriptionType.exists(_ =:= schema.ref("Subscription")))
+
+  }
+
+  ignore("no query type (crashes)") {
+    Schema("scalar Foo").right.get.queryType
+  }
+
 }


### PR DESCRIPTION
This changes `QueryCompiler.compile` to return `Result[Operation]` where `Operation(query: Query, rootTpe: Type)` which includes the selected root type. `QueryExecutor` uses this by default when invoking the interpreter (it had been using `schema.queryType` in all cases). 

`Operation` is a bit overloaded so maybe `RootedQuery` or something would be a better name.

This fixes a few problems:

- It was not possible to declare `schema { ... }` because it was expecting `NamedType` fields but they're actually `NullableTyped(NamedType)` as parsed.
- In the absence of a `schema { ... }` declaration we were defaulting to `schema { query: Query }` which ignored `type Mutation` and `type Subscription` when present. We now delegate to the [correct] superclass behavior in this case.

(this supersedes #110)
