### PR TITLE
WIP: mutation

### DIFF
--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -14,7 +14,7 @@ import ScalarType._
 import org.tpolecat.sourcepos.SourcePos
 
 abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
-  case class CirceRoot(val tpe: Type, val fieldName: String, root: Json)(
+  case class CirceRoot(val tpe: Type, val fieldName: String, root: Json, mutation: Mutation)(
     implicit val pos: SourcePos
   ) extends RootMapping {
     def cursor(query: Query, env: Env): F[Result[Cursor]] = {
@@ -26,12 +26,12 @@ abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
       CirceCursor(Nil, cursorTpe, root, None, env).rightIor.pure[F].widen
     }
     def withParent(tpe: Type): CirceRoot =
-      new CirceRoot(tpe, fieldName, root)
+      new CirceRoot(tpe, fieldName, root, mutation)
   }
 
   object CirceRoot {
-    def apply(fieldName: String, root: Json): CirceRoot =
-      new CirceRoot(NoType, fieldName, root)
+    def apply(fieldName: String, root: Json, mutation: Mutation = Mutation.None): CirceRoot =
+      new CirceRoot(NoType, fieldName, root, mutation)
   }
 
   case class CirceCursor(

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -16,7 +16,7 @@ import org.tpolecat.sourcepos.SourcePos
 
 abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
 
-  case class ValueRoot(val tpe: Type, val fieldName: String, root0: () => Any)(
+  case class ValueRoot(val tpe: Type, val fieldName: String, root0: () => Any, mutation: Mutation)(
     implicit val pos: SourcePos
   ) extends RootMapping {
     lazy val root: Any = root0()
@@ -29,12 +29,12 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
       ValueCursor(Nil, cursorTpe, root, None, env).rightIor.pure[F].widen
     }
     def withParent(tpe: Type): ValueRoot =
-      new ValueRoot(tpe, fieldName, root0)
+      new ValueRoot(tpe, fieldName, root0, mutation)
   }
 
   object ValueRoot {
-    def apply(fieldName: String, root: => Any)(implicit pos: SourcePos): ValueRoot =
-      new ValueRoot(NoType, fieldName, () => root)
+    def apply(fieldName: String, root: => Any, mutation: Mutation = Mutation.None)(implicit pos: SourcePos): ValueRoot =
+      new ValueRoot(NoType, fieldName, () => root, mutation)
   }
 
   sealed trait ValueField0[T] extends FieldMapping

--- a/modules/doobie/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie/src/main/scala/DoobieMapping.scala
@@ -16,7 +16,7 @@ import _root_.doobie.util.fragments
 import java.sql.ResultSet
 
 abstract class DoobieMapping[F[_]: Sync](
-      transactor: Transactor[F],
+  val transactor: Transactor[F],
   val monitor:    DoobieMonitor[F]
 ) extends SqlMapping[F] {
 

--- a/modules/doobie/src/test/scala/mutation/MutationData.scala
+++ b/modules/doobie/src/test/scala/mutation/MutationData.scala
@@ -1,0 +1,141 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package mutation
+
+import _root_.doobie._
+import _root_.doobie.implicits._
+import cats.effect.{ Bracket, Sync }
+import cats.syntax.all._
+import edu.gemini.grackle._
+import edu.gemini.grackle.doobie.DoobieMapping
+import edu.gemini.grackle.doobie.DoobieMappingCompanion
+import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.Query._
+import edu.gemini.grackle.QueryCompiler._
+import edu.gemini.grackle.Value._
+import edu.gemini.grackle.doobie.DoobieMonitor
+
+trait MutationSchema[F[_]] extends DoobieMapping[F] {
+
+  class TableDef(name: String) {
+    def col(colName: String, codec: Codec[_]): ColumnRef =
+      ColumnRef(name, colName, codec)
+  }
+
+  object country extends TableDef("country") {
+    val code = col("code", Meta[String])
+    val name = col("name", Meta[String])
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", Meta[Int])
+    val countrycode = col("countrycode", Meta[String])
+    val name        = col("name", Meta[String])
+    val population  = col("population", Meta[Int])
+  }
+
+}
+
+trait MutationMapping[F[_]] extends MutationSchema[F] {
+
+  implicit def ev: Bracket[F, Throwable]
+
+  val schema =
+    Schema(
+      """
+        type Query {
+          city(id: Int!): City
+        }
+        type Mutation {
+          updatePopulation(id: Int!, population: Int!): City
+        }
+        type City {
+          name: String!
+          country: Country!
+          population: Int!
+        }
+        type Country {
+          name: String!
+          cities: [City!]!
+        }
+      """
+    ).right.get
+
+  val QueryType    = schema.ref("Query")
+  val MutationType = schema.ref("Mutation")
+  val CountryType  = schema.ref("Country")
+  val CityType     = schema.ref("City")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings = List(
+          SqlRoot("city"),
+        ),
+      ),
+      ObjectMapping(
+        tpe = MutationType,
+        fieldMappings = List(
+          SqlRoot("updatePopulation", mutation = Mutation.unit { (_, e) =>
+            (e.get[Int]("id"), e.get[Int]("population")).tupled match {
+              case None =>
+                QueryInterpreter.mkErrorResult(s"Implementation error, expected id and population in $e.").pure[F]
+              case Some((id, pop)) =>
+                sql"update city set population=$pop where id=$id"
+                  .update
+                  .run
+                  .transact(transactor)
+                  .as(().rightIor)
+              }
+          }),
+        ),
+      ),
+       ObjectMapping(
+        tpe = CountryType,
+        fieldMappings = List(
+          SqlAttribute("code", country.code, key = true),
+          SqlField("name",     country.name),
+          SqlObject("cities",  Join(country.code, city.countrycode)),
+        ),
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings = List(
+          SqlAttribute("id", city.id, key = true),
+          SqlAttribute("countrycode", city.countrycode),
+          SqlField("name", city.name),
+          SqlField("population", city.population),
+          SqlObject("country", Join(city.countrycode, country.code)),
+        )
+      ),
+    )
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("city", List(Binding("id", IntValue(id))), child) =>
+        Select("city", Nil, Unique(Eql(AttrPath(List("id")), Const(id)), child)).rightIor
+    },
+    MutationType -> {
+      case Select("updatePopulation", List(Binding("id", IntValue(id)), Binding("population", IntValue(pop))), child) =>
+        Environment(
+          Cursor.Env("id" -> id, "population" -> pop),
+          Select("updatePopulation", Nil,
+            // We could also do this in the SqlRoot's mutation, and in fact would need to do so if
+            // the mutation generated a new id. But for now it seems easiest to do it here.
+            Unique(Eql(AttrPath(List("id")), Const(id)), child)
+          )
+        ).rightIor
+    }
+  ))
+}
+
+object MutationMapping extends DoobieMappingCompanion {
+
+  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F] =
+    new DoobieMapping[F](transactor, monitor) with MutationMapping[F] {
+      val ev = Sync[F]
+    }
+
+}

--- a/modules/doobie/src/test/scala/mutation/MutationSpec.scala
+++ b/modules/doobie/src/test/scala/mutation/MutationSpec.scala
@@ -7,5 +7,5 @@ import utils.DatabaseSuite
 import grackle.test.SqlMutationSpec
 
 final class MutationSpec extends DatabaseSuite with SqlMutationSpec {
-  lazy val mapping = MutationMapping.mkMapping(pool)
+  lazy val mapping = MutationMapping.fromTransactor(xa)
 }

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -20,17 +20,17 @@ import ShapelessUtils._
 import org.tpolecat.sourcepos.SourcePos
 
 abstract class GenericMapping[F[_]: Monad] extends Mapping[F] {
-  case class GenericRoot[T](val tpe: Type, val fieldName: String, t: T, cb: () => CursorBuilder[T])(
+  case class GenericRoot[T](val tpe: Type, val fieldName: String, t: T, cb: () => CursorBuilder[T], mutation: Mutation)(
     implicit val pos: SourcePos
   ) extends RootMapping {
     lazy val cursorBuilder = cb()
     def cursor(query: Query, env: Env): F[Result[Cursor]] = cursorBuilder.build(Nil, t, None, env).pure[F]
     def withParent(tpe: Type): GenericRoot[T] =
-      new GenericRoot(tpe, fieldName, t, cb)
+      new GenericRoot(tpe, fieldName, t, cb, mutation)
   }
 
-  def GenericRoot[T](fieldName: String, t: T)(implicit cb: => CursorBuilder[T]): GenericRoot[T] =
-    new GenericRoot(NoType, fieldName, t, () => cb)
+  def GenericRoot[T](fieldName: String, t: T, mutation: Mutation = Mutation.None)(implicit cb: => CursorBuilder[T]): GenericRoot[T] =
+    new GenericRoot(NoType, fieldName, t, () => cb, mutation)
 }
 
 object semiauto {

--- a/modules/skunk/src/main/scala/skunkmapping.scala
+++ b/modules/skunk/src/main/scala/skunkmapping.scala
@@ -14,7 +14,7 @@ import edu.gemini.grackle.sql._
 import scala.util.control.NonFatal
 
 abstract class SkunkMapping[F[_]: Sync](
-      pool:    Resource[F, Session[F]],
+  val pool:    Resource[F, Session[F]],
   val monitor: SkunkMonitor[F]
 ) extends SqlMapping[F] { outer =>
 

--- a/modules/skunk/src/test/scala/mutation/MutationData.scala
+++ b/modules/skunk/src/test/scala/mutation/MutationData.scala
@@ -1,0 +1,141 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package mutation
+
+import cats.effect.{ Bracket, Resource, Sync }
+import cats.syntax.all._
+import edu.gemini.grackle._
+import edu.gemini.grackle.QueryCompiler._
+import edu.gemini.grackle.Query._
+import edu.gemini.grackle.Value._
+import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.skunk._
+import _root_.skunk.Session
+import _root_.skunk.implicits._
+import _root_.skunk.codec.all._
+import cats.data.IorT
+
+trait MutationSchema[F[_]] extends SkunkMapping[F] {
+
+  class TableDef(name: String) {
+    def col(colName: String, codec: Codec[_]): ColumnRef =
+      ColumnRef(name, colName, codec)
+  }
+
+  object country extends TableDef("country") {
+    val code = col("code", bpchar(3))
+    val name = col("name", text)
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", int4)
+    val countrycode = col("countrycode", bpchar(3))
+    val name        = col("name", text)
+    val population  = col("population", int4)
+  }
+
+}
+
+trait MutationMapping[F[_]] extends MutationSchema[F] {
+
+  implicit def ev: Bracket[F, Throwable]
+
+  val schema =
+    Schema(
+      """
+        type Query {
+          city(id: Int!): City
+        }
+        type Mutation {
+          updatePopulation(id: Int!, population: Int!): City
+        }
+        type City {
+          name: String!
+          country: Country!
+          population: Int!
+        }
+        type Country {
+          name: String!
+          cities: [City!]!
+        }
+      """
+    ).right.get
+
+  val QueryType    = schema.ref("Query")
+  val MutationType = schema.ref("Mutation")
+  val CountryType  = schema.ref("Country")
+  val CityType     = schema.ref("City")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings = List(
+          SqlRoot("city"),
+        ),
+      ),
+      ObjectMapping(
+        tpe = MutationType,
+        fieldMappings = List(
+          SqlRoot("updatePopulation", mutation = Mutation.unit { (_, e) =>
+            (e.get[Int]("id"), e.get[Int]("population")).tupled match {
+              case None =>
+                QueryInterpreter.mkErrorResult(s"Implementation error, expected id and population in $e.").pure[F]
+              case Some((id, pop)) =>
+                pool.use { s =>
+                  s.prepare(sql"update city set population=$int4 where id=$int4".command).use { ps =>
+                    IorT.right(ps.execute(pop ~ id).void).value // awkward
+                  }
+                }
+              }
+          }),
+        ),
+      ),
+       ObjectMapping(
+        tpe = CountryType,
+        fieldMappings = List(
+          SqlAttribute("code", country.code, key = true),
+          SqlField("name",     country.name),
+          SqlObject("cities",  Join(country.code, city.countrycode)),
+        ),
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings = List(
+          SqlAttribute("id", city.id, key = true),
+          SqlAttribute("countrycode", city.countrycode),
+          SqlField("name", city.name),
+          SqlField("population", city.population),
+          SqlObject("country", Join(city.countrycode, country.code)),
+        )
+      ),
+    )
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("city", List(Binding("id", IntValue(id))), child) =>
+        Select("city", Nil, Unique(Eql(AttrPath(List("id")), Const(id)), child)).rightIor
+    },
+    MutationType -> {
+      case Select("updatePopulation", List(Binding("id", IntValue(id)), Binding("population", IntValue(pop))), child) =>
+        Environment(
+          Cursor.Env("id" -> id, "population" -> pop),
+          Select("updatePopulation", Nil,
+            // We could also do this in the SqlRoot's mutation, and in fact would need to do so if
+            // the mutation generated a new id. But for now it seems easiest to do it here.
+            Unique(Eql(AttrPath(List("id")), Const(id)), child)
+          )
+        ).rightIor
+    }
+  ))
+}
+
+object MutationMapping extends SkunkMappingCompanion {
+
+  def mkMapping[F[_]: Sync](pool: Resource[F,Session[F]], monitor: SkunkMonitor[F]): Mapping[F] =
+    new SkunkMapping[F](pool, monitor) with MutationMapping[F] {
+      val ev = Sync[F]
+    }
+
+}

--- a/modules/skunk/src/test/scala/mutation/MutationSpec.scala
+++ b/modules/skunk/src/test/scala/mutation/MutationSpec.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package mutation
+
+import utils.DatabaseSuite
+
+final class MutationSpec extends DatabaseSuite with SqlMutationSpec {
+  lazy val mapping = MutationMapping.mkMapping(pool)
+}

--- a/modules/skunk/src/test/scala/mutation/SqlMutationSpec.scala
+++ b/modules/skunk/src/test/scala/mutation/SqlMutationSpec.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package mutation
+
+import org.scalatest.funsuite.AnyFunSuite
+import edu.gemini.grackle.QueryExecutor
+import cats.effect.IO
+import io.circe.Json
+import io.circe.literal._
+
+trait SqlMutationSpec extends AnyFunSuite {
+
+  def mapping: QueryExecutor[IO, Json]
+
+  def check(query: String, expected: Json) =
+    assert(mapping.compileAndRun(query).unsafeRunSync() == expected)
+
+  test("sanity check") {
+    check("""
+        query {
+          city(id: 1) {
+            name
+            population
+          }
+        }
+      """,
+      json"""
+        {
+          "data": {
+            "city": {
+              "name": "Kabul",
+              "population" : 1780000
+            }
+          }
+        }
+      """
+    )
+  }
+
+
+  test("simple update") {
+    check("""
+        mutation {
+          updatePopulation(id: 2, population: 12345) {
+            name
+            population
+            country {
+              name
+            }
+          }
+        }
+      """,
+      json"""
+        {
+          "data" : {
+            "updatePopulation" : {
+              "name" : "Qandahar",
+              "population" : 12345,
+              "country" : {
+                "name" : "Afghanistan"
+              }
+            }
+          }
+        }
+      """
+    )
+  }
+
+
+}

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -95,7 +95,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       Fragments.const(s"${parent.toSql} = ${child.toSql}")
   }
 
-  case class SqlRoot(fieldName: String, path: List[String] = Nil, rootTpe: Type = NoType)(
+  case class SqlRoot(fieldName: String, path: List[String] = Nil, rootTpe: Type = NoType, mutation: Mutation = Mutation.None)(
     implicit val pos: SourcePos
   ) extends RootMapping {
 
@@ -1130,7 +1130,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   // overrides
 
   override def rootMapping(path: List[String], tpe: Type, fieldName: String): Option[RootMapping] =
-    if (tpe =:= schema.queryType) super.rootMapping(path, tpe, fieldName)
+    if (tpe =:= schema.queryType || schema.mutationType.exists(_ == tpe)) super.rootMapping(path, tpe, fieldName)
     else Some(SqlRoot(fieldName, path, tpe))
 
   override def compilerPhases: List[QueryCompiler.Phase] =

--- a/modules/sql/src/test/resources/db/mutation.sql
+++ b/modules/sql/src/test/resources/db/mutation.sql
@@ -1,0 +1,3 @@
+
+-- A sequence to test out inserting into a table.
+CREATE SEQUENCE city_id START WITH 5000;

--- a/modules/sql/src/test/scala/SqlMutationSpec.scala
+++ b/modules/sql/src/test/scala/SqlMutationSpec.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package mutation
+package grackle.test
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor
@@ -15,29 +15,6 @@ trait SqlMutationSpec extends AnyFunSuite {
 
   def check(query: String, expected: Json) =
     assert(mapping.compileAndRun(query).unsafeRunSync() == expected)
-
-  test("sanity check") {
-    check("""
-        query {
-          city(id: 1) {
-            name
-            population
-          }
-        }
-      """,
-      json"""
-        {
-          "data": {
-            "city": {
-              "name": "Kabul",
-              "population" : 1780000
-            }
-          }
-        }
-      """
-    )
-  }
-
 
   test("simple update") {
     check("""


### PR DESCRIPTION
This adds support for mutation as follows:

- `RootMapping` now has a `mutation` member of type `Mutation` (a wrapper for `(Query, Env) => F[Result[(Query, Env)]]`). All constructors default this value to `Mutation.None`, which does nothing.
- A `Mutation` performs effects in `F` and yields a [possibly updated] query and env.
- The `QueryInterpreter` executes the mutation and uses the [possibly updated] query and env to construct the result cursor.
- For the doobie and Skunk mappings the updates and subsequent queries run in separate transactions, which I think is actually what we want, given the "mutate and then query" semantics in the spec. In any case _not_ doing it this way would be a significant complication so I'm calling it good for now.

Todo:

- [x] Add an database insert test that generates a new key.
- [x] Implement database tests for doobie.

It's a pretty small change, which makes me hopeful. More comments inline.
