### PR TITLE
initial subscriptions implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val catsTestkitScalaTestVersion = "2.1.2"
 val circeVersion                = "0.13.0"
 val circeOpticsVersion          = "0.13.0"
 val doobieVersion               = "0.10.0"
+val fs2Version                  = "2.5.4"
 val http4sVersion               = "0.21.20"
 val kindProjectorVersion        = "0.11.3"
 val logbackVersion              = "1.2.3"
@@ -67,7 +68,8 @@ lazy val core = project
       "io.circe"          %% "circe-optics"           % circeOpticsVersion,
       "io.circe"          %% "circe-parser"           % circeVersion,
       "org.tpolecat"      %% "typename"               % typenameVersion,
-      "org.tpolecat"      %% "sourcepos"              % sourcePosVersion
+      "org.tpolecat"      %% "sourcepos"              % sourcePosVersion,
+      "co.fs2"            %% "fs2-core"               % fs2Version,
     )
   )
 

--- a/modules/core/src/main/scala/package.scala
+++ b/modules/core/src/main/scala/package.scala
@@ -5,6 +5,7 @@ package edu.gemini
 
 import cats.data.IorNec
 import io.circe.Json
+import cats.data.Ior
 
 package object grackle {
   /**
@@ -14,4 +15,10 @@ package object grackle {
    * Json, or both.
    */
   type Result[T] = IorNec[Json, T]
+
+  object Result {
+    // A successful result, infers better than `x.rightIor`
+    def apply[A](a: A): Result[A] = Ior.right(a)
+  }
+
 }

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -93,7 +93,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get)
+    val res = FragmentMapping.run(compiled.right.get).compile.toList.head
     //println(res)
     assert(res == expectedResult)
   }
@@ -181,7 +181,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get)
+    val res = FragmentMapping.run(compiled.right.get).compile.toList.head
     //println(res)
     assert(res == expectedResult)
   }
@@ -258,7 +258,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get)
+    val res = FragmentMapping.run(compiled.right.get).compile.toList.head
     //println(res)
     assert(res == expectedResult)
   }
@@ -323,7 +323,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get)
+    val res = FragmentMapping.run(compiled.right.get).compile.toList.head
     //println(res)
     assert(res == expectedResult)
   }
@@ -423,7 +423,7 @@ final class FragmentSuite extends CatsSuite {
 
     assert(compiled.map(_.query) == Ior.Right(expected))
 
-    val res = FragmentMapping.run(compiled.right.get)
+    val res = FragmentMapping.run(compiled.right.get).compile.toList.head
     //println(res)
     assert(res == expectedResult)
   }

--- a/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
+++ b/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
@@ -5,17 +5,17 @@ package edu.gemini.grackle
 package doobie
 
 import _root_.doobie.util.transactor.Transactor
-import cats.Monad
-import cats.arrow.FunctionK
-import cats.data.StateT
+// import cats.Monad
+// import cats.arrow.FunctionK
+// import cats.data.StateT
 import cats.effect.Sync
-import cats.implicits._
+// import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import io.circe.Json
+// import io.circe.Json
 
-import Cursor.Env
-import QueryCompiler.IntrospectionLevel
-import IntrospectionLevel.Full
+// import Cursor.Env
+// import QueryCompiler.IntrospectionLevel
+// import IntrospectionLevel.Full
 
 trait DoobieMappingCompanion {
   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
@@ -37,21 +37,21 @@ trait LoggedDoobieMappingCompanion {
   }
 }
 
-trait TracedDoobieMappingCompanion {
-  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
+// trait TracedDoobieMappingCompanion {
+//   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
 
-  def fromTransactor[F[_] : Sync](transactor: Transactor[F]): QueryExecutor[F, (Json, List[List[DoobieStats]])] = {
-    def liftF[T](ft: F[T]): StateT[F, List[List[DoobieStats]], T] = StateT.liftF(ft)
-    val stateMapping = mkMapping(transactor.mapK(FunctionK.lift(liftF)), DoobieMonitor.stateMonitor[F])
+//   def fromTransactor[F[_] : Sync](transactor: Transactor[F]): QueryExecutor[F, (Json, List[List[DoobieStats]])] = {
+//     def liftF[T](ft: F[T]): StateT[F, List[List[DoobieStats]], T] = StateT.liftF(ft)
+//     val stateMapping = mkMapping(transactor.mapK(FunctionK.lift(liftF)), DoobieMonitor.stateMonitor[F])
 
-    new QueryExecutor[F, (Json, List[List[DoobieStats]])] {
-      implicit val M: Monad[F] = Sync[F]
+//     new QueryExecutor[F, (Json, List[List[DoobieStats]])] {
+//       implicit val M: Monad[F] = Sync[F]
 
-      def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[DoobieStats]])] =
-        stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
+//       def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[DoobieStats]])] =
+//         stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
 
-      def compileAndRun(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[DoobieStats]])] =
-        stateMapping.compileAndRun(text, name, untypedVars, introspectionLevel).run(Nil).map(_.swap)
-    }
-  }
-}
+//       def compileAndRun(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[DoobieStats]])] =
+//         stateMapping.compileAndRun(text, name, untypedVars, introspectionLevel).run(Nil).map(_.swap)
+//     }
+//   }
+// }

--- a/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
+++ b/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
@@ -5,17 +5,8 @@ package edu.gemini.grackle
 package doobie
 
 import _root_.doobie.util.transactor.Transactor
-// import cats.Monad
-// import cats.arrow.FunctionK
-// import cats.data.StateT
 import cats.effect.Sync
-// import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-// import io.circe.Json
-
-// import Cursor.Env
-// import QueryCompiler.IntrospectionLevel
-// import IntrospectionLevel.Full
 
 trait DoobieMappingCompanion {
   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
@@ -36,22 +27,3 @@ trait LoggedDoobieMappingCompanion {
     mkMapping(transactor, monitor)
   }
 }
-
-// trait TracedDoobieMappingCompanion {
-//   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
-
-//   def fromTransactor[F[_] : Sync](transactor: Transactor[F]): QueryExecutor[F, (Json, List[List[DoobieStats]])] = {
-//     def liftF[T](ft: F[T]): StateT[F, List[List[DoobieStats]], T] = StateT.liftF(ft)
-//     val stateMapping = mkMapping(transactor.mapK(FunctionK.lift(liftF)), DoobieMonitor.stateMonitor[F])
-
-//     new QueryExecutor[F, (Json, List[List[DoobieStats]])] {
-//       implicit val M: Monad[F] = Sync[F]
-
-//       def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[DoobieStats]])] =
-//         stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
-
-//       def compileAndRun(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[DoobieStats]])] =
-//         stateMapping.compileAndRun(text, name, untypedVars, introspectionLevel).run(Nil).map(_.swap)
-//     }
-//   }
-// }

--- a/modules/doobie/src/main/scala/package.scala
+++ b/modules/doobie/src/main/scala/package.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+
+import edu.gemini.grackle.sql.SqlMonitor
+import _root_.doobie.Fragment
+
+package object doobie {
+  type DoobieMonitor[F[_]] = SqlMonitor[F, Fragment]
+}

--- a/modules/doobie/src/test/scala/coalesce/CoalesceData.scala
+++ b/modules/doobie/src/test/scala/coalesce/CoalesceData.scala
@@ -77,7 +77,7 @@ trait CoalesceMapping[F[_]] extends DoobieMapping[F] {
     )
 }
 
-object CoalesceMapping extends TracedDoobieMappingCompanion {
+object CoalesceMapping extends DoobieMappingCompanion {
 
   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F] =
     new DoobieMapping[F](transactor, monitor) with CoalesceMapping[F]

--- a/modules/doobie/src/test/scala/coalesce/CoalesceSpec.scala
+++ b/modules/doobie/src/test/scala/coalesce/CoalesceSpec.scala
@@ -5,8 +5,21 @@ package coalesce
 
 import utils.DatabaseSuite
 import grackle.test.SqlCoalesceSpec
-import edu.gemini.grackle.doobie.DoobieStats
+import cats.effect.IO
+import edu.gemini.grackle.sql.SqlStatsMonitor
+import edu.gemini.grackle.doobie.DoobieMonitor
+import edu.gemini.grackle.sql.SqlMonitor
+import edu.gemini.grackle.QueryExecutor
+import io.circe.Json
 
-final class CoalesceSpec extends DatabaseSuite with SqlCoalesceSpec[DoobieStats] {
-  lazy val mapping = CoalesceMapping.fromTransactor(xa)
+final class CoalesceSpec extends DatabaseSuite with SqlCoalesceSpec {
+
+  type Fragment = _root_.doobie.Fragment
+
+  def monitor: IO[SqlStatsMonitor[IO,Fragment]] =
+    DoobieMonitor.statsMonitor[IO]
+
+  def mapping(monitor: SqlMonitor[IO,Fragment]): QueryExecutor[IO, Json] =
+    CoalesceMapping.mkMapping(xa, monitor)
+
 }

--- a/modules/doobie/src/test/scala/world/WorldCompilerSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldCompilerSpec.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package world
+
+import utils.DatabaseSuite
+import edu.gemini.grackle.sql.{SqlStatsMonitor}
+import cats.effect.IO
+import edu.gemini.grackle.QueryExecutor
+import edu.gemini.grackle.sql.SqlMonitor
+import io.circe.Json
+import grackle.test.SqlWorldCompilerSpec
+import edu.gemini.grackle.doobie.DoobieMonitor
+
+final class WorldCompilerSpec extends DatabaseSuite with SqlWorldCompilerSpec {
+
+  type Fragment = doobie.Fragment
+
+  def monitor: IO[SqlStatsMonitor[IO,Fragment]] =
+    DoobieMonitor.statsMonitor[IO]
+
+  def mapping(monitor: SqlMonitor[IO,Fragment]): QueryExecutor[IO,Json] =
+    WorldMapping.mkMapping(xa, monitor)
+
+  def simpleRestrictedQuerySql: String =
+    "SELECT country.name, country.code FROM country WHERE (country.code = ?)"
+
+}

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -13,6 +13,7 @@ import shapeless.{ Coproduct, Generic, ::, HList, HNil, Inl, Inr, LabelledGeneri
 import shapeless.ops.hlist.{ LiftAll => PLiftAll }
 import shapeless.ops.coproduct.{ LiftAll => CLiftAll }
 import shapeless.ops.record.Keys
+import fs2.Stream
 
 import Cursor.Env
 import QueryInterpreter.{ mkErrorResult, mkOneError }
@@ -24,7 +25,7 @@ abstract class GenericMapping[F[_]: Monad] extends Mapping[F] {
     implicit val pos: SourcePos
   ) extends RootMapping {
     lazy val cursorBuilder = cb()
-    def cursor(query: Query, env: Env): F[Result[Cursor]] = cursorBuilder.build(Nil, t, None, env).pure[F]
+    def cursor(query: Query, env: Env): Stream[F,Result[Cursor]] = cursorBuilder.build(Nil, t, None, env).pure[Stream[F,*]]
     def withParent(tpe: Type): GenericRoot[T] =
       new GenericRoot(Some(tpe), fieldName, t, cb, mutation)
   }

--- a/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
+++ b/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
@@ -5,16 +5,7 @@ package edu.gemini.grackle
 package skunk
 
 import _root_.skunk.Session
-// import cats.arrow.FunctionK
-// import cats.data.StateT
 import cats.effect.{ Resource, Sync }
-// import cats.Monad
-// import cats.syntax.functor._
-// import io.circe.Json
-
-// import Cursor.Env
-// import QueryCompiler.IntrospectionLevel
-// import IntrospectionLevel.Full
 
 trait SkunkMappingCompanion {
 
@@ -24,41 +15,3 @@ trait SkunkMappingCompanion {
     mkMapping(pool, SkunkMonitor.noopMonitor)
 
 }
-
-// trait LoggedSkunkMappingCompanion {
-//   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: SkunkMonitor[F]): Mapping[F]
-
-//   def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): Mapping[F] = {
-//     val monitor: SkunkMonitor[F] = SkunkMonitor.loggerMonitor[F](Logger[F])
-
-//     mkMapping(transactor, monitor)
-//   }
-// }
-
-// trait TracedSkunkMappingCompanion {
-
-//   def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F]
-
-//   def fromSessionPool[F[_] : Sync](pool: Resource[F, Session[F]]): QueryExecutor[F, (Json, List[List[SkunkStats]])] = {
-
-//     type G[A] = StateT[F, List[List[SkunkStats]], A]
-
-//     def liftF[T](ft: F[T]): G[T] = StateT.liftF(ft)
-
-//     val sm: SkunkMonitor[G] = SkunkMonitor.stateMonitor[F]
-
-//     val fk: FunctionK[F, G] = FunctionK.lift(liftF)
-
-//     val stateMapping = mkMapping(pool.mapK(fk).map(_.mapK(fk)), sm)
-
-//     new QueryExecutor[F, (Json, List[List[SkunkStats]])] {
-//       implicit val M: Monad[F] = Sync[F]
-
-//       def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[SkunkStats]])] =
-//         stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
-
-//       def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[SkunkStats]])] =
-//         stateMapping.compileAndRun(text, name, untypedEnv, introspectionLevel, env).run(Nil).map(_.swap)
-//     }
-//   }
-// }

--- a/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
+++ b/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
@@ -5,16 +5,16 @@ package edu.gemini.grackle
 package skunk
 
 import _root_.skunk.Session
-import cats.arrow.FunctionK
-import cats.data.StateT
+// import cats.arrow.FunctionK
+// import cats.data.StateT
 import cats.effect.{ Resource, Sync }
-import cats.Monad
-import cats.syntax.functor._
-import io.circe.Json
+// import cats.Monad
+// import cats.syntax.functor._
+// import io.circe.Json
 
-import Cursor.Env
-import QueryCompiler.IntrospectionLevel
-import IntrospectionLevel.Full
+// import Cursor.Env
+// import QueryCompiler.IntrospectionLevel
+// import IntrospectionLevel.Full
 
 trait SkunkMappingCompanion {
 
@@ -35,30 +35,30 @@ trait SkunkMappingCompanion {
 //   }
 // }
 
-trait TracedSkunkMappingCompanion {
+// trait TracedSkunkMappingCompanion {
 
-  def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F]
+//   def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F]
 
-  def fromSessionPool[F[_] : Sync](pool: Resource[F, Session[F]]): QueryExecutor[F, (Json, List[List[SkunkStats]])] = {
+//   def fromSessionPool[F[_] : Sync](pool: Resource[F, Session[F]]): QueryExecutor[F, (Json, List[List[SkunkStats]])] = {
 
-    type G[A] = StateT[F, List[List[SkunkStats]], A]
+//     type G[A] = StateT[F, List[List[SkunkStats]], A]
 
-    def liftF[T](ft: F[T]): G[T] = StateT.liftF(ft)
+//     def liftF[T](ft: F[T]): G[T] = StateT.liftF(ft)
 
-    val sm: SkunkMonitor[G] = SkunkMonitor.stateMonitor[F]
+//     val sm: SkunkMonitor[G] = SkunkMonitor.stateMonitor[F]
 
-    val fk: FunctionK[F, G] = FunctionK.lift(liftF)
+//     val fk: FunctionK[F, G] = FunctionK.lift(liftF)
 
-    val stateMapping = mkMapping(pool.mapK(fk).map(_.mapK(fk)), sm)
+//     val stateMapping = mkMapping(pool.mapK(fk).map(_.mapK(fk)), sm)
 
-    new QueryExecutor[F, (Json, List[List[SkunkStats]])] {
-      implicit val M: Monad[F] = Sync[F]
+//     new QueryExecutor[F, (Json, List[List[SkunkStats]])] {
+//       implicit val M: Monad[F] = Sync[F]
 
-      def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[SkunkStats]])] =
-        stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
+//       def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[SkunkStats]])] =
+//         stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
 
-      def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[SkunkStats]])] =
-        stateMapping.compileAndRun(text, name, untypedEnv, introspectionLevel, env).run(Nil).map(_.swap)
-    }
-  }
-}
+//       def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[SkunkStats]])] =
+//         stateMapping.compileAndRun(text, name, untypedEnv, introspectionLevel, env).run(Nil).map(_.swap)
+//     }
+//   }
+// }

--- a/modules/skunk/src/main/scala/SkunkMonitor.scala
+++ b/modules/skunk/src/main/scala/SkunkMonitor.scala
@@ -8,7 +8,7 @@ import _root_.skunk.AppliedFragment
 import cats.Applicative
 import cats.implicits._
 import edu.gemini.grackle.QueryInterpreter.ProtoJson
-import cats.data.StateT
+// import cats.data.StateT
 import edu.gemini.grackle.sql._
 
 trait SkunkMonitor[F[_]] extends SqlMonitor[F, AppliedFragment] {
@@ -57,32 +57,32 @@ object SkunkMonitor {
 //         logger.info(s"stage completed")
 //     }
 
-  def stateMonitor[F[_]: Applicative]: SkunkMonitor[StateT[F, List[List[SkunkStats]], *]] =
-    new SkunkMonitor[StateT[F, List[List[SkunkStats]], *]] {
+  // def stateMonitor[F[_]: Applicative]: SkunkMonitor[StateT[F, List[List[SkunkStats]], *]] =
+  //   new SkunkMonitor[StateT[F, List[List[SkunkStats]], *]] {
 
-      def stageStarted: StateT[F, List[List[SkunkStats]], Unit] =
-        StateT.modify(states => Nil :: states)
+  //     def stageStarted: StateT[F, List[List[SkunkStats]], Unit] =
+  //       StateT.modify(states => Nil :: states)
 
-      def queryMapped(query: Query, fragment: AppliedFragment, table: List[Row]): StateT[F, List[List[SkunkStats]], Unit] = {
-        val stats =
-          SkunkStats(
-            query,
-            fragment.fragment.sql,
-            fragment.argument,
-            table.size,
-            table.headOption.map(_.elems.size).getOrElse(0),
-          )
+  //     def queryMapped(query: Query, fragment: AppliedFragment, table: List[Row]): StateT[F, List[List[SkunkStats]], Unit] = {
+  //       val stats =
+  //         SkunkStats(
+  //           query,
+  //           fragment.fragment.sql,
+  //           fragment.argument,
+  //           table.size,
+  //           table.headOption.map(_.elems.size).getOrElse(0),
+  //         )
 
-        StateT.modify {
-          case Nil => List(List(stats))
-          case hd :: tl => (stats :: hd) :: tl
-        }
-      }
+  //       StateT.modify {
+  //         case Nil => List(List(stats))
+  //         case hd :: tl => (stats :: hd) :: tl
+  //       }
+  //     }
 
-      def resultComputed(result: Result[ProtoJson]): StateT[F, List[List[SkunkStats]], Unit] =
-        StateT.pure(())
+  //     def resultComputed(result: Result[ProtoJson]): StateT[F, List[List[SkunkStats]], Unit] =
+  //       StateT.pure(())
 
-      def stageCompleted: StateT[F, List[List[SkunkStats]], Unit] =
-        StateT.pure(())
-    }
+  //     def stageCompleted: StateT[F, List[List[SkunkStats]], Unit] =
+  //       StateT.pure(())
+  //   }
 }

--- a/modules/skunk/src/main/scala/SkunkMonitor.scala
+++ b/modules/skunk/src/main/scala/SkunkMonitor.scala
@@ -8,15 +8,9 @@ import _root_.skunk.AppliedFragment
 import cats.Applicative
 import cats.implicits._
 import edu.gemini.grackle.QueryInterpreter.ProtoJson
-// import cats.data.StateT
 import edu.gemini.grackle.sql._
-
-trait SkunkMonitor[F[_]] extends SqlMonitor[F, AppliedFragment] {
-  def stageStarted: F[Unit]
-  def queryMapped(query: Query, fragment: AppliedFragment, table: List[Row]): F[Unit]
-  def resultComputed(result: Result[ProtoJson]): F[Unit]
-  def stageCompleted: F[Unit]
-}
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
 
 case class SkunkStats(
   query: Query,
@@ -27,6 +21,7 @@ case class SkunkStats(
 )
 
 object SkunkMonitor {
+
   def noopMonitor[F[_]: Applicative]: SkunkMonitor[F] =
     new SkunkMonitor[F] {
       def stageStarted: F[Unit] = ().pure[F]
@@ -35,54 +30,14 @@ object SkunkMonitor {
       def stageCompleted: F[Unit] = ().pure[F]
     }
 
-//   def loggerMonitor[F[_]: Applicative](logger: Logger[F]): SkunkMonitor[F] =
-//     new SkunkMonitor[F] {
-//       import FragmentAccess._
+  def statsMonitor[F[_]: Sync]: F[SqlStatsMonitor[F, AppliedFragment]] =
+    Ref[F].of(List.empty[SqlStatsMonitor.SqlStats]).map { ref =>
+      new SqlStatsMonitor[F, AppliedFragment](ref) {
+        def inspect(af: AppliedFragment): (String, List[Any]) = {
+          val (f, a) = (af.fragment, af.argument)
+          (f.sql, f.encoder.encode(a).map(_.getOrElse("null")))
+        }
+      }
+    }
 
-//       def stageStarted: F[Unit] =
-//         logger.info(s"stage started")
-
-//       def queryMapped(query: Query, fragment: AppliedFragment, table: List[Row]): F[Unit] =
-//         logger.info(
-//           s"""query: $query
-//              |sql: ${fragment.sql}
-//              |args: ${fragment.args.mkString(", ")}
-//              |fetched ${table.size} row(s) of ${table.headOption.map(_.elems.size).getOrElse(0)} column(s)
-//            """.stripMargin)
-
-//       def resultComputed(result: Result[ProtoJson]): F[Unit] =
-//         logger.info(s"result: $result")
-
-//       def stageCompleted: F[Unit] =
-//         logger.info(s"stage completed")
-//     }
-
-  // def stateMonitor[F[_]: Applicative]: SkunkMonitor[StateT[F, List[List[SkunkStats]], *]] =
-  //   new SkunkMonitor[StateT[F, List[List[SkunkStats]], *]] {
-
-  //     def stageStarted: StateT[F, List[List[SkunkStats]], Unit] =
-  //       StateT.modify(states => Nil :: states)
-
-  //     def queryMapped(query: Query, fragment: AppliedFragment, table: List[Row]): StateT[F, List[List[SkunkStats]], Unit] = {
-  //       val stats =
-  //         SkunkStats(
-  //           query,
-  //           fragment.fragment.sql,
-  //           fragment.argument,
-  //           table.size,
-  //           table.headOption.map(_.elems.size).getOrElse(0),
-  //         )
-
-  //       StateT.modify {
-  //         case Nil => List(List(stats))
-  //         case hd :: tl => (stats :: hd) :: tl
-  //       }
-  //     }
-
-  //     def resultComputed(result: Result[ProtoJson]): StateT[F, List[List[SkunkStats]], Unit] =
-  //       StateT.pure(())
-
-  //     def stageCompleted: StateT[F, List[List[SkunkStats]], Unit] =
-  //       StateT.pure(())
-  //   }
 }

--- a/modules/skunk/src/main/scala/package.scala
+++ b/modules/skunk/src/main/scala/package.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+
+import edu.gemini.grackle.sql.SqlMonitor
+import _root_.skunk.AppliedFragment
+
+package object skunk {
+  type SkunkMonitor[F[_]] = SqlMonitor[F, AppliedFragment]
+}

--- a/modules/skunk/src/test/scala/coalesce/CoalesceData.scala
+++ b/modules/skunk/src/test/scala/coalesce/CoalesceData.scala
@@ -78,7 +78,7 @@ trait CoalesceMapping[F[_]] extends SkunkMapping[F] {
     )
 }
 
-object CoalesceMapping extends TracedSkunkMappingCompanion {
+object CoalesceMapping extends SkunkMappingCompanion {
 
   def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F] =
     new SkunkMapping[F](pool, monitor) with CoalesceMapping[F]

--- a/modules/skunk/src/test/scala/coalesce/CoalesceSpec.scala
+++ b/modules/skunk/src/test/scala/coalesce/CoalesceSpec.scala
@@ -4,9 +4,23 @@
 package coalesce
 
 import utils.DatabaseSuite
-import edu.gemini.grackle.skunk.SkunkStats
 import grackle.test.SqlCoalesceSpec
+import edu.gemini.grackle.sql.{SqlStatsMonitor}
+import cats.effect.IO
+import edu.gemini.grackle.QueryExecutor
+import edu.gemini.grackle.sql.SqlMonitor
+import io.circe.Json
+import skunk.AppliedFragment
+import edu.gemini.grackle.skunk.SkunkMonitor
 
-final class CoalesceSpec extends DatabaseSuite with SqlCoalesceSpec[SkunkStats] {
-  lazy val mapping = CoalesceMapping.mkMapping(pool)
+final class CoalesceSpec extends DatabaseSuite with SqlCoalesceSpec {
+
+  type Fragment = AppliedFragment
+
+  def monitor: IO[SqlStatsMonitor[IO,Fragment]] =
+    SkunkMonitor.statsMonitor[IO]
+
+  def mapping(monitor: SqlMonitor[IO,Fragment]): QueryExecutor[IO,Json] =
+    CoalesceMapping.mkMapping(pool, monitor)
+
 }

--- a/modules/skunk/src/test/scala/coalesce/CoalesceSpec.scala
+++ b/modules/skunk/src/test/scala/coalesce/CoalesceSpec.scala
@@ -8,5 +8,5 @@ import edu.gemini.grackle.skunk.SkunkStats
 import grackle.test.SqlCoalesceSpec
 
 final class CoalesceSpec extends DatabaseSuite with SqlCoalesceSpec[SkunkStats] {
-  lazy val mapping = CoalesceMapping.fromSessionPool(pool)
+  lazy val mapping = CoalesceMapping.mkMapping(pool)
 }

--- a/modules/skunk/src/test/scala/subscription/SubscriptionData.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionData.scala
@@ -1,0 +1,134 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package subscription
+
+import _root_.skunk.codec.all._
+import _root_.skunk.implicits._
+import _root_.skunk.Session
+import cats.effect.{ Bracket, Resource, Sync }
+import cats.syntax.all._
+import edu.gemini.grackle._
+import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.Query._
+import edu.gemini.grackle.QueryCompiler._
+import edu.gemini.grackle.skunk._
+import edu.gemini.grackle.Value._
+
+trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
+
+  val schema =
+    Schema(
+      """
+        type Query {
+          city(id: Int!): City
+          channel: City!
+        }
+        type Subscription {
+          channel: City!
+        }
+        type City {
+          name: String!
+          country: Country!
+          population: Int!
+        }
+        type Country {
+          name: String!
+          cities: [City!]!
+        }
+      """
+    ).right.get
+
+  class TableDef(name: String) {
+    def col(colName: String, codec: Codec[_]): ColumnRef =
+      ColumnRef(name, colName, codec)
+  }
+
+  object country extends TableDef("country") {
+    val code = col("code", bpchar(3))
+    val name = col("name", text)
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", int4)
+    val countrycode = col("countrycode", bpchar(3))
+    val name        = col("name", text)
+    val population  = col("population", int4)
+  }
+
+  implicit def ev: Bracket[F, Throwable]
+
+  val QueryType        = schema.ref("Query")
+  val SubscriptionType = schema.ref("Subscription")
+  val CountryType      = schema.ref("Country")
+  val CityType         = schema.ref("City")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings = List(
+          SqlRoot("city"),
+          SqlRoot(
+            fieldName = "channel",
+            mutation  = Mutation { (q, e) =>
+              for {
+                s  <- fs2.Stream.resource(pool)
+                id <- s.channel(id"city_channel").listen(256).map(_.value.toInt)
+                qʹ  = Unique(Eql(AttrPath(List("id")), Const(id)), q)
+              } yield Result((qʹ, e))
+            }
+          ),
+        ),
+      ),
+      ObjectMapping(
+        tpe = CountryType,
+        fieldMappings = List(
+          SqlAttribute("code", country.code, key = true),
+          SqlField("name",     country.name),
+          SqlObject("cities",  Join(country.code, city.countrycode)),
+        ),
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings = List(
+          SqlAttribute("id", city.id, key = true),
+          SqlAttribute("countrycode", city.countrycode),
+          SqlField("name", city.name),
+          SqlField("population", city.population),
+          SqlObject("country", Join(city.countrycode, country.code)),
+        )
+      ),
+      ObjectMapping(
+        tpe = SubscriptionType,
+        fieldMappings = List(
+          SqlRoot(
+            fieldName = "channel",
+            mutation  = Mutation { (q, e) =>
+              for {
+                s  <- fs2.Stream.resource(pool)
+                id <- s.channel(id"city_changes").listen(256).map(_.value.toInt)
+                qʹ  = Unique(Eql(AttrPath(List("id")), Const(id)), q)
+              } yield Result((qʹ, e))
+            }
+          ),
+        ),
+      ),
+    )
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("city", List(Binding("id", IntValue(id))), child) =>
+        Select("city", Nil, Unique(Eql(AttrPath(List("id")), Const(id)), child)).rightIor
+    },
+  ))
+}
+
+object SubscriptionMapping extends SkunkMappingCompanion {
+
+  def mkMapping[F[_]: Sync](pool: Resource[F,Session[F]], monitor: SkunkMonitor[F]): Mapping[F] =
+    new SkunkMapping[F](pool, monitor) with SubscriptionMapping[F] {
+      val ev = Sync[F]
+    }
+
+}

--- a/modules/skunk/src/test/scala/subscription/SubscriptionData.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionData.scala
@@ -22,7 +22,6 @@ trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
       """
         type Query {
           city(id: Int!): City
-          channel: City!
         }
         type Subscription {
           channel: City!
@@ -69,16 +68,6 @@ trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
         tpe = QueryType,
         fieldMappings = List(
           SqlRoot("city"),
-          SqlRoot(
-            fieldName = "channel",
-            mutation  = Mutation { (q, e) =>
-              for {
-                s  <- fs2.Stream.resource(pool)
-                id <- s.channel(id"city_channel").listen(256).map(_.value.toInt)
-                qʹ  = Unique(Eql(AttrPath(List("id")), Const(id)), q)
-              } yield Result((qʹ, e))
-            }
-          ),
         ),
       ),
       ObjectMapping(
@@ -107,7 +96,7 @@ trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
             mutation  = Mutation { (q, e) =>
               for {
                 s  <- fs2.Stream.resource(pool)
-                id <- s.channel(id"city_changes").listen(256).map(_.value.toInt)
+                id <- s.channel(id"city_channel").listen(256).map(_.value.toInt)
                 qʹ  = Unique(Eql(AttrPath(List("id")), Const(id)), q)
               } yield Result((qʹ, e))
             }

--- a/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
@@ -16,7 +16,7 @@ class SubscriptionSpec extends DatabaseSuite {
   test("subscription driven by a Postgres channel") {
 
     val query = """
-      query {
+      subscription {
         channel {
           name
           country {
@@ -57,7 +57,7 @@ class SubscriptionSpec extends DatabaseSuite {
       for {
 
         // start a fiber that subscibes and takes the first two notifications
-        fi <- mapping.compileAndRunAll(query).take(2).compile.toList.start
+        fi <- mapping.compileAndRunAll(query).evalTap(r => IO(println(s"got $r"))).take(2).compile.toList.start
 
         // We're racing now, so wait a sec before starting notifications
         _  <- IO.sleep(1.second)

--- a/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
@@ -1,0 +1,80 @@
+package subscription
+
+import utils.DatabaseSuite
+import io.circe.literal._
+import io.circe.Json
+import cats.effect.IO
+import skunk.implicits._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+
+class SubscriptionSpec extends DatabaseSuite {
+
+  lazy val mapping = SubscriptionMapping.mkMapping(pool)
+  implicit val ioTimer = IO.timer(ExecutionContext.global)
+
+  test("subscription driven by a Postgres channel") {
+
+    val query = """
+      query {
+        channel {
+          name
+          country {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = List(
+      json"""
+        {
+          "data" : {
+            "channel" : {
+              "name" : "Godoy Cruz",
+              "country" : {
+                "name" : "Argentina"
+              }
+            }
+          }
+        }
+      """,
+      json"""
+        {
+          "data" : {
+            "channel" : {
+              "name" : "Posadas",
+              "country" : {
+                "name" : "Argentina"
+              }
+            }
+          }
+        }
+      """,
+    )
+
+    val prog: IO[List[Json]] =
+      for {
+
+        // start a fiber that subscibes and takes the first two notifications
+        fi <- mapping.compileAndRunAll(query).take(2).compile.toList.start
+
+        // We're racing now, so wait a sec before starting notifications
+        _  <- IO.sleep(1.second)
+
+        // Send some notifications through Postgres, which will trigger queries on the subscription.
+        _  <- pool.use { s =>
+                val ch = s.channel(id"city_channel").contramap[Int](_.toString)
+                List(101, 102, 103).traverse_(ch.notify)
+              }
+
+        // Now rejoin the fiber
+        js <- fi.join
+
+      } yield js
+
+    // Done
+    assert(prog.unsafeRunSync() == expected)
+
+  }
+}

--- a/modules/skunk/src/test/scala/world/WorldCompilerSpec.scala
+++ b/modules/skunk/src/test/scala/world/WorldCompilerSpec.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package world
+
+import utils.DatabaseSuite
+import edu.gemini.grackle.sql.{SqlStatsMonitor}
+import cats.effect.IO
+import edu.gemini.grackle.QueryExecutor
+import edu.gemini.grackle.sql.SqlMonitor
+import io.circe.Json
+import skunk.AppliedFragment
+import edu.gemini.grackle.skunk.SkunkMonitor
+import grackle.test.SqlWorldCompilerSpec
+
+final class WorldCompilerSpec extends DatabaseSuite with SqlWorldCompilerSpec {
+
+  type Fragment = AppliedFragment
+
+  def monitor: IO[SqlStatsMonitor[IO,Fragment]] =
+    SkunkMonitor.statsMonitor[IO]
+
+  def mapping(monitor: SqlMonitor[IO,Fragment]): QueryExecutor[IO,Json] =
+    WorldMapping.mkMapping(pool, monitor)
+
+  def simpleRestrictedQuerySql: String =
+    "SELECT country.name, country.code FROM country WHERE (country.code = $1)"
+
+}

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -12,6 +12,7 @@ import cats.implicits._
 import io.circe.Json
 import org.tpolecat.typename._
 import org.tpolecat.sourcepos.SourcePos
+import fs2.Stream
 
 import Cursor.Env
 import Predicate._
@@ -108,16 +109,18 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       } yield SqlCursor(fieldPath, cursorType, table, mapped, None, env).rightIor
     }
 
-    def cursor(query: Query, env: Env): F[Result[Cursor]] =
-      if (fieldName === "__staged")
-        orootTpe.map(rootTpe => mkRootCursor(query, path, rootTpe, env)).getOrElse(mkErrorResult(s"No root type").pure[F])
-      else
-        (for {
-          rootTpe  <- orootTpe
-          fieldTpe <- rootTpe.underlyingField(fieldName)
-        } yield {
-          mkRootCursor(query, fieldName :: path, fieldTpe, env)
-        }).getOrElse(mkErrorResult(s"Type ${orootTpe.getOrElse("unspecified type")} has no field '$fieldName'").pure[F])
+    def cursor(query: Query, env: Env): Stream[F,Result[Cursor]] =
+      Stream.eval {
+        if (fieldName === "__staged")
+          orootTpe.map(rootTpe => mkRootCursor(query, path, rootTpe, env)).getOrElse(mkErrorResult(s"No root type").pure[F])
+        else
+          (for {
+            rootTpe  <- orootTpe
+            fieldTpe <- rootTpe.underlyingField(fieldName)
+          } yield {
+            mkRootCursor(query, fieldName :: path, fieldTpe, env)
+          }).getOrElse(mkErrorResult(s"Type ${orootTpe.getOrElse("unspecified type")} has no field '$fieldName'").pure[F])
+        }
 
     def withParent(tpe: Type): SqlRoot =
       copy(orootTpe = Some(tpe))
@@ -1174,20 +1177,20 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   override val interpreter: QueryInterpreter[F] =
     new QueryInterpreter(this) {
 
-      override def runRootValues(queries: List[(Query, Type, Env)]): F[(Chain[Json], List[ProtoJson])] =
+      override def runRootValues(queries: List[(Query, Type, Env)]): Stream[F,(Chain[Json], List[ProtoJson])] =
         for {
-          _   <- monitor.stageStarted
+          _   <- Stream.eval(monitor.stageStarted)
           res <- runRootValues0(queries)
-          _   <- monitor.stageCompleted
+          _   <- Stream.eval(monitor.stageCompleted)
         } yield res
 
-      override def runRootValue(query: Query, rootTpe: Type, env: Env): F[Result[ProtoJson]] =
+      override def runRootValue(query: Query, rootTpe: Type, env: Env): Stream[F,Result[ProtoJson]] =
         for {
           res <- super.runRootValue(query, rootTpe, env)
-          _   <- monitor.resultComputed(res)
+          _   <- Stream.eval(monitor.resultComputed(res))
         } yield res
 
-      def runRootValues0(queries: List[(Query, Type, Env)]): F[(Chain[Json], List[ProtoJson])] = {
+      def runRootValues0(queries: List[(Query, Type, Env)]): Stream[F,(Chain[Json], List[ProtoJson])] = {
         if (queries.length === 1)
           super.runRootValues(queries)
         else {

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -1168,7 +1168,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   // overrides
 
   override def rootMapping(path: List[String], tpe: Type, fieldName: String): Option[RootMapping] =
-    if (tpe =:= schema.queryType || schema.mutationType.exists(_ == tpe)) super.rootMapping(path, tpe, fieldName)
+    if (tpe =:= schema.queryType || schema.mutationType.exists(_ == tpe) || schema.subscriptionType.exists(_ == tpe)) super.rootMapping(path, tpe, fieldName)
     else Some(SqlRoot(fieldName, path, Some(tpe)))
 
   override def compilerPhases: List[QueryCompiler.Phase] =

--- a/modules/sql/src/main/scala/SqlStatsMonitor.scala
+++ b/modules/sql/src/main/scala/SqlStatsMonitor.scala
@@ -45,12 +45,18 @@ abstract class SqlStatsMonitor[F[_]: Applicative, A](
 
 object SqlStatsMonitor {
 
-  case class SqlStats(
-    query: Query,
-    sql:   String,
-    args:  List[Any],
-    rows:  Int,
-    cols:  Int
-  )
+  final case class SqlStats(
+    val query: Query,
+    val sql:   String,
+    val args:  List[Any],
+    val rows:  Int,
+    val cols:  Int
+  ) {
+
+    /** Normalize whitespace in `query` for easier testing. */
+    def normalize: SqlStats =
+      copy(sql = sql.replaceAll("\\s+", " ").trim)
+
+  }
 
 }

--- a/modules/sql/src/main/scala/SqlStatsMonitor.scala
+++ b/modules/sql/src/main/scala/SqlStatsMonitor.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql
+
+import cats.Applicative
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+import edu.gemini.grackle.{ Query, Result, QueryInterpreter }
+
+import SqlStatsMonitor.SqlStats
+
+/**
+ * A SqlMonitor that accumulates `SqlStats` in a `Ref`. Stage boundaries and results are not
+ * tracked.
+ */
+abstract class SqlStatsMonitor[F[_]: Applicative, A](
+  ref: Ref[F, List[SqlStats]]
+) extends SqlMonitor[F, A] {
+
+  /** Get the current state and reset it to `Nil`. */
+  final def take: F[List[SqlStats]] =
+    ref.getAndSet(Nil).map(_.reverse)
+
+  final def stageStarted: F[Unit] =
+    Applicative[F].unit
+
+  final def queryMapped(query: Query, fragment: A, table: List[Row]): F[Unit] =
+    ref.update { stats =>
+      val (sql, args) = inspect(fragment)
+      SqlStats(query, sql, args, table.size, table.headOption.foldMap(_.elems.length)) :: stats
+    }
+
+  final def resultComputed(result: Result[QueryInterpreter.ProtoJson]): F[Unit] =
+    Applicative[F].unit
+
+  final def stageCompleted: F[Unit] =
+    Applicative[F].unit
+
+
+  /** Extract the SQL string and query arguments from a fragment. */
+  def inspect(fragment: A): (String, List[Any])
+
+}
+
+object SqlStatsMonitor {
+
+  case class SqlStats(
+    query: Query,
+    sql:   String,
+    args:  List[Any],
+    rows:  Int,
+    cols:  Int
+  )
+
+}

--- a/modules/sql/src/test/scala/SqlCoalesceSpec.scala
+++ b/modules/sql/src/test/scala/SqlCoalesceSpec.scala
@@ -8,11 +8,15 @@ import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor
 import cats.effect.IO
 import io.circe.Json
-import scala.language.reflectiveCalls
+
+// N.B. stats-collection is turned off for now; see commented lines below
+
+// import scala.language.reflectiveCalls
 
 trait SqlCoalesceSpec[A <: { def rows: Int ; def cols: Int }] extends AnyFunSuite {
 
-  def mapping: QueryExecutor[IO, (Json, List[List[A]])]
+  // def mapping: QueryExecutor[IO, (Json, List[List[A]])]
+  def mapping: QueryExecutor[IO, Json]
 
   test("simple coalesced query") {
     val query = """
@@ -89,19 +93,19 @@ trait SqlCoalesceSpec[A <: { def rows: Int ; def cols: Int }] extends AnyFunSuit
       }
     """
 
-    val (res, trace) = mapping.compileAndRun(query).unsafeRunSync()
-    //println(res)
+    // val (res, trace) = mapping.compileAndRun(query).unsafeRunSync()
+    val res = mapping.compileAndRun(query).unsafeRunSync()
 
     assert(res == expected)
 
-    val numStages = trace.size
-    val numCells = trace.foldLeft(0) { case (acc, stage) =>
-      acc+stage.foldLeft(0) { case (acc, stats) =>
-        acc+(stats.rows*stats.cols)
-      }
-    }
+    // val numStages = trace.size
+    // val numCells = trace.foldLeft(0) { case (acc, stage) =>
+    //   acc+stage.foldLeft(0) { case (acc, stats) =>
+    //     acc+(stats.rows*stats.cols)
+    //   }
+    // }
 
-    assert(numStages == 2)
-    assert(numCells == 32)
+    // assert(numStages == 2)
+    // assert(numCells == 32)
   }
 }

--- a/modules/sql/src/test/scala/SqlWorldCompilerSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldCompilerSpec.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package grackle.test
+
+import io.circe.literal.JsonStringContext
+import org.scalatest.funsuite.AnyFunSuite
+import edu.gemini.grackle.QueryExecutor
+import cats.effect.IO
+import io.circe.Json
+import edu.gemini.grackle.sql.SqlStatsMonitor
+import edu.gemini.grackle.sql.SqlMonitor
+import edu.gemini.grackle.Query
+import edu.gemini.grackle.Predicate._
+
+/** Tests that confirm the compiler is writing the queries we want. */
+trait SqlWorldCompilerSpec extends AnyFunSuite {
+
+  type Fragment
+  def monitor: IO[SqlStatsMonitor[IO, Fragment]]
+  def mapping(monitor: SqlMonitor[IO, Fragment]): QueryExecutor[IO, Json]
+
+  /** Expected SQL string for the simple restricted query test. */
+  def simpleRestrictedQuerySql: String
+
+  test("simple restricted query") {
+
+    val query =
+      """
+        query {
+          country(code: "GBR") {
+            name
+          }
+        }
+      """
+
+    val expected =
+      json"""
+        {
+          "data": {
+            "country": {
+              "name": "United Kingdom"
+            }
+          }
+        }
+      """
+
+    val prog: IO[(Json, List[SqlStatsMonitor.SqlStats])] =
+      for {
+        mon <- monitor
+        map  = mapping(mon)
+        res <- map.compileAndRun(query)
+        ss  <- mon.take
+      } yield (res, ss.map(_.normalize))
+
+    val (res, stats) = prog.unsafeRunSync()
+
+    assert(res == expected)
+
+    assert(
+      stats == List(
+        SqlStatsMonitor.SqlStats(
+          Query.Unique(Eql(AttrPath(List("code")),Const("GBR")),Query.Select("name",List(),Query.Empty)),
+          simpleRestrictedQuerySql,
+          List("GBR"),
+          1,
+          2
+        )
+      )
+    )
+
+  }
+
+}


### PR DESCRIPTION
The strategy in #132 doesn't work in general ... we really do need to recognize that a GraphQL query can return many results in order to support subscriptions. Despite the changes here the existing API is mostly unbroken and the tests mostly compile and run unchanged.

- [x] change `QueryInterpreter` and underlying machinery (primarily `RootMapping`) to return streams.
- [x] figure out a way to make stats-collection work in the streaming case
- [ ] ~~add a test for a simple subscription driven by a queue~~ deferring this to a followup
- [x] add a test for a database subscription driven by a Postgres channel 

This also adds `SqlStatsMonitor` that collects stats in a `Ref`, allowing you to examine them after a stream has completed. It's minimal but sufficient for testing that the query compiler is doing the right thing, which is the immediate use case.