### PR TITLE
effectful value roots

### DIFF
--- a/modules/core/src/main/scala/package.scala
+++ b/modules/core/src/main/scala/package.scala
@@ -6,6 +6,7 @@ package edu.gemini
 import cats.data.IorNec
 import io.circe.Json
 import cats.data.Ior
+import cats.data.NonEmptyChain
 
 package object grackle {
   /**
@@ -14,11 +15,21 @@ package object grackle {
    * A result of type `T`, a non-empty collection of errors encoded as
    * Json, or both.
    */
-  type Result[T] = IorNec[Json, T]
+  type Result[+T] = IorNec[Json, T]
 
   object Result {
-    // A successful result, infers better than `x.rightIor`
+
+    val unit: Result[Unit] =
+      apply(())
+
     def apply[A](a: A): Result[A] = Ior.right(a)
+
+    def failure[A](s: String): Result[A] =
+      failure(Json.fromString(s))
+
+    def failure[A](j: Json): Result[A] =
+      Ior.left(NonEmptyChain(j))
+
   }
 
 }

--- a/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
@@ -1,0 +1,157 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package subscription
+
+import cats.effect.IO
+import cats.tests.CatsSuite
+import edu.gemini.grackle.Mapping
+import edu.gemini.grackle.Result
+import edu.gemini.grackle.Schema
+import edu.gemini.grackle.ValueMapping
+import fs2.concurrent.SignallingRef
+import fs2.Stream
+import edu.gemini.grackle.Query
+import scala.concurrent.ExecutionContext
+import io.circe.Json
+import io.circe.literal._
+import edu.gemini.grackle.QueryCompiler
+import edu.gemini.grackle.Value
+import edu.gemini.grackle.Cursor
+import scala.concurrent.duration._
+
+final class SubscriptionSpec extends CatsSuite {
+
+  implicit val ioContextShift = IO.contextShift(ExecutionContext.global)
+  implicit val ioTimer        = IO.timer(ExecutionContext.global)
+
+  def mapping(ref: SignallingRef[IO, Int]): Mapping[IO] =
+    new ValueMapping[IO] {
+
+      val schema: Schema =
+        Schema("""
+          type Query {
+            get: Int!
+          }
+          type Mutation {
+            put(n: Int): Int!
+          }
+          type Subscription {
+            watch: Int!
+          }
+        """).right.get
+
+      val QueryType        = schema.ref("Query")
+      val MutationType     = schema.ref("Mutation")
+      val SubscriptionType = schema.ref("Subscription")
+
+      val typeMappings: List[TypeMapping] =
+        List(
+          ObjectMapping(QueryType, List(
+            ValueRoot.liftF("get", ref.get)
+          )),
+          ObjectMapping(MutationType, List(
+            ValueRoot.liftF("put", ref.get, Mutation.unit { case (_, e) =>
+              e.get[Int]("n") match {
+                case None    => Result.failure(s"Implementation error: `n: Int` not found in $e").pure[Stream[IO,*]]
+                case Some(n) => Stream.eval(ref.set(n).as(Result.unit))
+              }
+            })
+          )),
+          ObjectMapping(SubscriptionType, List(
+            ValueRoot.liftF("watch", ref.get, Mutation { case (q, e) =>
+              ref.discrete.as(Result((q,e)))
+            })
+          )),
+        )
+
+      override val selectElaborator: QueryCompiler.SelectElaborator =
+        new QueryCompiler.SelectElaborator(Map(
+          MutationType -> {
+            case Query.Select("put", List(Query.Binding("n", Value.IntValue(n))), child) =>
+              Result(Query.Environment(Cursor.Env("n" -> n), Query.Select("put", Nil, child)))
+          }
+        ))
+
+    }
+
+    test("sanity check (get, put, get)") {
+
+      val prog: IO[(Json, Json, Json)] =
+        for {
+          ref <- SignallingRef[IO, Int](0)
+          map  = mapping(ref)
+          r0  <- map.compileAndRunOne("query { get }")
+          r1  <- map.compileAndRunOne("mutation { put(n: 42) }")
+          r2  <- map.compileAndRunOne("query { get }")
+        } yield (r0, r1, r2)
+
+      assert(prog.unsafeRunSync() == ((
+        json"""
+          {
+            "data" : {
+              "get" : 0
+            }
+          }
+        """,
+        json"""
+          {
+            "data" : {
+              "put" : 42
+            }
+          }
+        """,
+        json"""
+          {
+            "data" : {
+              "get" : 42
+            }
+          }
+        """
+      )))
+
+    }
+
+    test("subscription") {
+
+      val prog: IO[List[Json]] =
+        for {
+          ref <- SignallingRef[IO, Int](0)
+          map  = mapping(ref)
+          fib <- map.compileAndRunAll("subscription { watch }").take(3).compile.toList.start
+          _   <- map.compileAndRunOne("mutation { put(n: 123) }")
+          _   <- IO.sleep(100.milli)
+          _   <- map.compileAndRunOne("mutation { put(n: 42) }")
+          _   <- IO.sleep(100.milli)
+          _   <- map.compileAndRunOne("mutation { put(n: 77) }")
+          _   <- IO.sleep(100.milli)
+          res <- fib.join
+        } yield res
+
+      assert(prog.unsafeRunSync() == List(
+        json"""
+          {
+            "data" : {
+              "watch" : 123
+            }
+          }
+        """,
+        json"""
+          {
+            "data" : {
+              "watch" : 42
+            }
+          }
+        """,
+        json"""
+          {
+            "data" : {
+              "watch" : 77
+            }
+          }
+        """,
+      ))
+
+    }
+
+}

--- a/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
@@ -120,7 +120,7 @@ final class SubscriptionSpec extends CatsSuite {
           map  = mapping(ref)
           fib <- map.compileAndRunAll("subscription { watch }").take(3).compile.toList.start
           _   <- map.compileAndRunOne("mutation { put(n: 123) }")
-          _   <- IO.sleep(100.milli)
+          _   <- IO.sleep(100.milli) // this is the best we can do for now; I will try to improve in a followup
           _   <- map.compileAndRunOne("mutation { put(n: 42) }")
           _   <- IO.sleep(100.milli)
           _   <- map.compileAndRunOne("mutation { put(n: 77) }")

--- a/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package subscription
 
 import utils.DatabaseSuite


### PR DESCRIPTION
This changes `ValueRoot` roots from thunks to effectful values. The existing API is unchanged modulo strictness, which hasn't caused any issues in tests or the demo module. I also added some more constructors to the `Result` object.

The real point of this change was to allow me to write the included `SubscriptionSpec`, which doesn't rely on a database and thus can live in core.