### PR TITLE
schema and json literals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val doobieVersion               = "0.10.0"
 val fs2Version                  = "2.5.4"
 val http4sVersion               = "0.21.20"
 val kindProjectorVersion        = "0.11.3"
+val literallyVersion            = "1.0.0"
 val logbackVersion              = "1.2.3"
 val log4catsVersion             = "1.1.1"
 val skunkVersion                = "0.0.24"
@@ -63,6 +64,7 @@ lazy val core = project
     libraryDependencies ++= Seq(
       "org.tpolecat"      %% "atto-core"              % attoVersion,
       "org.typelevel"     %% "cats-core"              % catsVersion,
+      "org.typelevel"     %% "literally"              % literallyVersion,
       "io.circe"          %% "circe-core"             % circeVersion,
       "io.circe"          %% "circe-literal"          % circeVersion,
       "io.circe"          %% "circe-optics"           % circeOpticsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,6 @@ lazy val core = project
       "org.typelevel"     %% "cats-core"              % catsVersion,
       "org.typelevel"     %% "literally"              % literallyVersion,
       "io.circe"          %% "circe-core"             % circeVersion,
-      "io.circe"          %% "circe-literal"          % circeVersion,
       "io.circe"          %% "circe-optics"           % circeOpticsVersion,
       "io.circe"          %% "circe-parser"           % circeVersion,
       "org.tpolecat"      %% "typename"               % typenameVersion,
@@ -87,7 +86,6 @@ lazy val circe = project
       "org.tpolecat"      %% "atto-core"              % attoVersion,
       "org.typelevel"     %% "cats-core"              % catsVersion,
       "io.circe"          %% "circe-core"             % circeVersion,
-      "io.circe"          %% "circe-literal"          % circeVersion,
       "io.circe"          %% "circe-optics"           % circeOpticsVersion,
       "io.circe"          %% "circe-parser"           % circeVersion
     )
@@ -154,7 +152,6 @@ lazy val generic = project
       "org.tpolecat"      %% "atto-core"              % attoVersion,
       "org.typelevel"     %% "cats-core"              % catsVersion,
       "io.circe"          %% "circe-core"             % circeVersion,
-      "io.circe"          %% "circe-literal"          % circeVersion,
       "io.circe"          %% "circe-optics"           % circeOpticsVersion,
       "io.circe"          %% "circe-parser"           % circeVersion,
       "com.chuusai"       %% "shapeless"              % shapelessVersion

--- a/demo/src/main/scala/starwars/StarWarsData.scala
+++ b/demo/src/main/scala/starwars/StarWarsData.scala
@@ -7,6 +7,7 @@ import cats.Id
 import cats.implicits._
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 
 import Query._, Predicate._, Value._
 import QueryCompiler._
@@ -145,41 +146,39 @@ object StarWarsMapping extends GenericMapping[Id] {
 
   // #schema
   val schema =
-    Schema(
-      """
-        type Query {
-           hero(episode: Episode!): Character!
-           character(id: ID!): Character
-           human(id: ID!): Human
-           droid(id: ID!): Droid
-         }
-         enum Episode {
-           NEWHOPE
-           EMPIRE
-           JEDI
-         }
-         interface Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-         }
-         type Human implements Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-           homePlanet: String
-         }
-         type Droid implements Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-           primaryFunction: String
-         }
-      """
-    ).right.get
+    schema"""
+      type Query {
+          hero(episode: Episode!): Character!
+          character(id: ID!): Character
+          human(id: ID!): Human
+          droid(id: ID!): Droid
+        }
+        enum Episode {
+          NEWHOPE
+          EMPIRE
+          JEDI
+        }
+        interface Character {
+          id: String!
+          name: String
+          friends: [Character!]
+          appearsIn: [Episode!]
+        }
+        type Human implements Character {
+          id: String!
+          name: String
+          friends: [Character!]
+          appearsIn: [Episode!]
+          homePlanet: String
+        }
+        type Droid implements Character {
+          id: String!
+          name: String
+          friends: [Character!]
+          appearsIn: [Episode!]
+          primaryFunction: String
+        }
+    """
   // #schema
 
   val QueryType = schema.ref("Query")

--- a/modules/circe/src/test/scala/CirceData.scala
+++ b/modules/circe/src/test/scala/CirceData.scala
@@ -5,46 +5,44 @@ package edu.gemini.grackle
 package circetests
 
 import cats.Id
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle.circe.CirceMapping
+import edu.gemini.grackle.syntax._
 
 object TestCirceMapping extends CirceMapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          root: Root
-        }
-        type Root {
-          bool: Boolean
-          int: Int
-          float: Float
-          string: String
-          id: ID
-          choice: Choice
-          arrary: [Int!]
-          object: A
-          children: [Child!]!
-        }
-        enum Choice {
-          ONE
-          TWO
-          THREE
-        }
-        interface Child {
-          id: ID
-        }
-        type A implements Child {
-          id: ID
-          aField: Int
-        }
-        type B implements Child {
-          id: ID
-          bField: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        root: Root
+      }
+      type Root {
+        bool: Boolean
+        int: Int
+        float: Float
+        string: String
+        id: ID
+        choice: Choice
+        arrary: [Int!]
+        object: A
+        children: [Child!]!
+      }
+      enum Choice {
+        ONE
+        TWO
+        THREE
+      }
+      interface Child {
+        id: ID
+      }
+      type A implements Child {
+        id: ID
+        aField: Int
+      }
+      type B implements Child {
+        id: ID
+        bField: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
 

--- a/modules/circe/src/test/scala/CirceSpec.scala
+++ b/modules/circe/src/test/scala/CirceSpec.scala
@@ -5,7 +5,7 @@ package edu.gemini.grackle
 package circetests
 
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 final class CirceSpec extends CatsSuite {
   test("scalars") {

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -9,6 +9,7 @@ import ScalarType._
 
 object Introspection {
   val schema =
+    // N.B. can't use schema"..." here because it's a macro defined in the same module
     Schema(
       """
         type Query {

--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -11,7 +11,28 @@ final case class Problem(
   message: String,
   locations: List[(Int, Int)] = Nil,
   path: List[String] = Nil
-)
+) {
+
+  override def toString = {
+
+    lazy val pathText: String =
+      path.mkString("/")
+
+    lazy val locationsText: String =
+      locations.map { case (a, b) =>
+        if (a == b) a.toString else s"$a..$b"
+      } .mkString(", ")
+
+    (path.nonEmpty, locations.nonEmpty) match {
+      case (true, true)   => s"$message (at $pathText: $locationsText)"
+      case (true, false)  => s"$message (at $pathText)"
+      case (false, true)  => s"$message (at $locationsText)"
+      case (false, false) => message
+    }
+
+  }
+
+}
 
 object Problem {
 

--- a/modules/core/src/main/scala/syntax.scala
+++ b/modules/core/src/main/scala/syntax.scala
@@ -20,7 +20,7 @@ object syntax {
     def validate(c: Context)(s: String): Either[String,c.Expr[Schema]] = {
       import c.universe._
       Schema(s).toEither.bimap(
-        nec => s"Invalid schema: ${Json.fromValues(nec.toList)}",
+        nec => s"Invalid schema:${nec.toList.distinct.mkString("\n  🐞 ", "\n  🐞 ", "\n")}",
         _ => c.Expr(q"_root_.edu.gemini.grackle.Schema($s).right.get")
       )
     }

--- a/modules/core/src/main/scala/syntax.scala
+++ b/modules/core/src/main/scala/syntax.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+
+import cats.syntax.all._
+import org.typelevel.literally.Literally
+import edu.gemini.grackle.Schema
+import io.circe.Json
+import io.circe.parser.parse
+
+object syntax {
+
+  implicit class StringContextOps(val sc: StringContext) extends AnyVal {
+    def schema(args: Any*): Schema = macro SchemaLiteral.make
+    def json(args: Any*): Json = macro JsonLiteral.make
+  }
+
+  object SchemaLiteral extends Literally[Schema] {
+    def validate(c: Context)(s: String): Either[String,c.Expr[Schema]] = {
+      import c.universe._
+      Schema(s).toEither.bimap(
+        nec => s"Invalid schema: ${Json.fromValues(nec.toList)}",
+        _ => c.Expr(q"_root_.edu.gemini.grackle.Schema($s).right.get")
+      )
+    }
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Schema] = apply(c)(args: _*)
+  }
+
+  object JsonLiteral extends Literally[Json] {
+    def validate(c: Context)(s: String): Either[String,c.Expr[Json]] = {
+      import c.universe._
+      parse(s).bimap(
+        pf => s"Invalid JSON: ${pf.message}",
+        _  => c.Expr(q"_root_.io.circe.parser.parse($s).toOption.get"),
+      )
+    }
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Json] = apply(c)(args: _*)
+  }
+
+}

--- a/modules/core/src/test/scala/compiler/Attributes.scala
+++ b/modules/core/src/test/scala/compiler/Attributes.scala
@@ -4,7 +4,7 @@
 package compiler
 
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 final class AttributesSpec extends CatsSuite {
   test("fields only") {

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -8,6 +8,7 @@ import cats.data.{Chain, Ior}
 import cats.implicits._
 import cats.tests.CatsSuite
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._, UntypedOperation._
 import QueryCompiler._, ComponentElaborator.TrivialJoin
 
@@ -347,18 +348,16 @@ final class CompilerSuite extends CatsSuite {
 
 object AtomicMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          character(id: String!): Character
-        }
-        type Character {
-          id: String!
-          name: String
-          friends: [Character!]
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        character(id: String!): Character
+      }
+      type Character {
+        id: String!
+        name: String
+        friends: [Character!]
+      }
+    """
 
   val QueryType = schema.ref("Query")
 
@@ -373,7 +372,7 @@ object AtomicMapping extends Mapping[Id] {
 }
 
 trait DummyComponent extends Mapping[Id] {
-  val schema = Schema("type Query { dummy: Int }").right.get
+  val schema = schema"type Query { dummy: Int }"
   val typeMappings = Nil
 }
 
@@ -383,30 +382,28 @@ object ComponentC extends DummyComponent
 
 object ComposedMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          componenta: ComponentA!
-        }
-        type ComponentA {
-          fielda1: String!
-          fielda2: FieldA2
-        }
-        type FieldA2 {
-          componentb: ComponentB
-        }
-        type ComponentB {
-          fieldb1: String!
-          fieldb2: FieldB2
-        }
-        type FieldB2 {
-          componentc: ComponentC
-        }
-        type ComponentC {
-          fieldc1: Int
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        componenta: ComponentA!
+      }
+      type ComponentA {
+        fielda1: String!
+        fielda2: FieldA2
+      }
+      type FieldA2 {
+        componentb: ComponentB
+      }
+      type ComponentB {
+        fieldb1: String!
+        fieldb2: FieldB2
+      }
+      type FieldB2 {
+        componentc: ComponentC
+      }
+      type ComponentC {
+        fieldc1: Int
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val FieldA2Type = schema.ref("FieldA2")

--- a/modules/core/src/test/scala/compiler/Environment.scala
+++ b/modules/core/src/test/scala/compiler/Environment.scala
@@ -6,9 +6,9 @@ package compiler
 import cats.Id
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Cursor.Env
 import Query._, Value._
 import QueryCompiler._
@@ -16,23 +16,21 @@ import QueryInterpreter.mkOneError
 
 object EnvironmentMapping extends ValueMapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          nested: Nested!
-          nestedSum(x: Int!, y: Int!): NestedSum!
-        }
-        type Nested {
-          sum(x: Int!, y: Int!): Int!
-          url: String!
-          nested: Nested!
-        }
-        type NestedSum {
-          sum: Int!
-          nestedSum(x: Int!, y: Int!): NestedSum!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        nested: Nested!
+        nestedSum(x: Int!, y: Int!): NestedSum!
+      }
+      type Nested {
+        sum(x: Int!, y: Int!): Int!
+        url: String!
+        nested: Nested!
+      }
+      type NestedSum {
+        sum: Int!
+        nestedSum(x: Int!, y: Int!): NestedSum!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val NestedType = schema.ref("Nested")

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -7,9 +7,9 @@ import cats.Id
 import cats.data.Ior
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 
@@ -461,31 +461,29 @@ object FragmentMapping extends ValueMapping[Id] {
   import FragmentData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          user(id: ID!): User!
-          profiles: [Profile!]!
-        }
-        type User implements Profile {
-          id: String!
-          name: String!
-          profilePic: String!
-          friends: [User!]!
-          mutualFriends: [User!]!
-          favourite: UserOrPage
-        }
-        type Page implements Profile {
-          id: String!
-          title: String!
-          likers: [User!]!
-        }
-        union UserOrPage = User | Page
-        interface Profile {
-          id: String!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        user(id: ID!): User!
+        profiles: [Profile!]!
+      }
+      type User implements Profile {
+        id: String!
+        name: String!
+        profilePic: String!
+        friends: [User!]!
+        mutualFriends: [User!]!
+        favourite: UserOrPage
+      }
+      type Page implements Profile {
+        id: String!
+        title: String!
+        likers: [User!]!
+      }
+      union UserOrPage = User | Page
+      interface Profile {
+        id: String!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val ProfileType = schema.ref("Profile")

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -8,6 +8,7 @@ import cats.data.{Chain, Ior}
 import cats.tests.CatsSuite
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Value._
 import QueryCompiler._
 
@@ -113,25 +114,23 @@ final class InputValuesSuite extends CatsSuite {
 
 object InputValuesMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          field(arg: Int): Result!
-          listField(arg: [String!]!): Result!
-          objectField(arg: InObj!): Result!
-        }
-        type Result {
-          subfield: String!
-        }
-        input InObj {
-          foo: Int!
-          bar: Boolean!
-          baz: String!
-          defaulted: String! = "quux"
-          nullable: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        field(arg: Int): Result!
+        listField(arg: [String!]!): Result!
+        objectField(arg: InObj!): Result!
+      }
+      type Result {
+        subfield: String!
+      }
+      input InObj {
+        foo: Int!
+        bar: Boolean!
+        baz: String!
+        defaulted: String! = "quux"
+        nullable: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
 

--- a/modules/core/src/test/scala/compiler/Predicates.scala
+++ b/modules/core/src/test/scala/compiler/Predicates.scala
@@ -6,9 +6,9 @@ package compiler
 import cats.Id
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 
@@ -23,21 +23,19 @@ object ItemMapping extends ValueMapping[Id] {
   import ItemData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          itemByTag(tag: ID!): [Item!]!
-          itemByTagCount(count: Int!): [Item!]!
-          itemByTagCountVA(count: Int!): [Item!]!
-          itemByTagCountCA(count: Int!): [Item!]!
-        }
-        type Item {
-          label: String!
-          tags: [String!]!
-          tagCount: Int!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        itemByTag(tag: ID!): [Item!]!
+        itemByTagCount(count: Int!): [Item!]!
+        itemByTagCountVA(count: Int!): [Item!]!
+        itemByTagCountCA(count: Int!): [Item!]!
+      }
+      type Item {
+        label: String!
+        tags: [String!]!
+        tagCount: Int!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val ItemType = schema.ref("Item")

--- a/modules/core/src/test/scala/compiler/ProblemSpec.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSpec.scala
@@ -4,10 +4,9 @@
 package compiler
 
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 import edu.gemini.grackle.Problem
 import io.circe.syntax._
-import io.circe.literal._
 
 final class ProblemSpec extends CatsSuite {
 

--- a/modules/core/src/test/scala/compiler/ProblemSpec.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSpec.scala
@@ -83,4 +83,28 @@ final class ProblemSpec extends CatsSuite {
     )
   }
 
+  test("toString (full)") {
+    assert(
+      Problem("foo", List(1 -> 2, 5 -> 6), List("bar", "baz")).toString == "foo (at bar/baz: 1..2, 5..6)"
+    )
+  }
+
+  test("toString (no path)") {
+    assert(
+      Problem("foo", List(1 -> 2, 5 -> 6), Nil).toString == "foo (at 1..2, 5..6)"
+    )
+  }
+
+  test("toString (no locations)") {
+    assert(
+      Problem("foo", Nil, List("bar", "baz")).toString == "foo (at bar/baz)"
+    )
+  }
+
+  test("toString (message only)") {
+    assert(
+      Problem("foo", Nil, Nil).toString == "foo"
+    )
+  }
+
 }

--- a/modules/core/src/test/scala/compiler/ScalarsSpec.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSpec.scala
@@ -10,9 +10,9 @@ import scala.util.Try
 import cats.{Eq, Id, Order}
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 
@@ -86,37 +86,35 @@ object MovieMapping extends ValueMapping[Id] {
   import MovieData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          movieById(id: UUID!): Movie
-          moviesByGenre(genre: Genre!): [Movie!]!
-          moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
-          moviesLongerThan(duration: Interval!): [Movie!]!
-          moviesShownLaterThan(time: Time!): [Movie!]!
-          moviesShownBetween(from: DateTime!, to: DateTime!): [Movie!]!
-        }
-        scalar UUID
-        scalar Time
-        scalar Date
-        scalar DateTime
-        scalar Interval
-        enum Genre {
-          DRAMA
-          ACTION
-          COMEDY
-        }
-        type Movie {
-          id: UUID!
-          title: String!
-          genre: Genre!
-          releaseDate: Date!
-          showTime: Time!
-          nextShowing: DateTime!
-          duration: Interval!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        movieById(id: UUID!): Movie
+        moviesByGenre(genre: Genre!): [Movie!]!
+        moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
+        moviesLongerThan(duration: Interval!): [Movie!]!
+        moviesShownLaterThan(time: Time!): [Movie!]!
+        moviesShownBetween(from: DateTime!, to: DateTime!): [Movie!]!
+      }
+      scalar UUID
+      scalar Time
+      scalar Date
+      scalar DateTime
+      scalar Interval
+      enum Genre {
+        DRAMA
+        ACTION
+        COMEDY
+      }
+      type Movie {
+        id: UUID!
+        title: String!
+        genre: Genre!
+        releaseDate: Date!
+        showTime: Time!
+        nextShowing: DateTime!
+        duration: Interval!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val MovieType = schema.ref("Movie")

--- a/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
@@ -6,9 +6,9 @@ package compiler
 import cats.Id
 import cats.data.Ior
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._
 
 final class SkipIncludeSuite extends CatsSuite {
@@ -247,17 +247,15 @@ final class SkipIncludeSuite extends CatsSuite {
 
 object SkipIncludeMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          field: Value!
-        }
-        type Value {
-          subfieldA: String
-          subfieldB: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        field: Value!
+      }
+      type Value {
+        subfieldA: String
+        subfieldB: String
+      }
+    """
 
   val typeMappings = Nil
 }

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -6,9 +6,9 @@ package compiler
 import cats.Id
 import cats.data.{Chain, Ior}
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Value._
 import QueryCompiler._
 
@@ -335,34 +335,32 @@ final class VariablesSuite extends CatsSuite {
 
 object VariablesMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          user(id: ID!): User!
-          users(ids: [ID!]!): [User!]!
-          search(pattern: Pattern!): [User!]!
-          usersByType(userType: UserType!): [User!]!
-          usersLoggedInByDate(date: Date!): [User!]!
-        }
-        type User {
-          id: String!
-          name: String!
-          profilePic(size: Int): String!
-        }
-        input Pattern {
-          name: String
-          age: Int
-          id: ID
-          userType: UserType
-          date: Date
-        }
-        enum UserType {
-          ADMIN
-          NORMAL
-        }
-        scalar Date
-      """
-    ).right.get
+    schema"""
+      type Query {
+        user(id: ID!): User!
+        users(ids: [ID!]!): [User!]!
+        search(pattern: Pattern!): [User!]!
+        usersByType(userType: UserType!): [User!]!
+        usersLoggedInByDate(date: Date!): [User!]!
+      }
+      type User {
+        id: String!
+        name: String!
+        profilePic(size: Int): String!
+      }
+      input Pattern {
+        name: String
+        age: Int
+        id: ID
+        userType: UserType
+        date: Date
+      }
+      enum UserType {
+        ADMIN
+        NORMAL
+      }
+      scalar Date
+    """
 
   val typeMappings = Nil
 

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -7,6 +7,7 @@ import cats.Id
 import cats.implicits._
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.mkErrorResult
@@ -29,17 +30,15 @@ object CurrencyMapping extends ValueMapping[Id] {
   import CurrencyData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          fx(code: String): Currency
-        }
-        type Currency {
-          code: String!
-          exchangeRate: Float!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        fx(code: String): Currency
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CurrencyType = schema.ref("Currency")
@@ -91,18 +90,16 @@ object CountryMapping extends ValueMapping[Id] {
   import CountryData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          country(code: String): Country
-          countries: [Country!]!
-        }
-        type Country {
-          code: String!
-          name: String!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        country(code: String): Country
+        countries: [Country!]!
+      }
+      type Country {
+        code: String!
+        name: String!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CountryType = schema.ref("Country")
@@ -141,24 +138,22 @@ object CountryMapping extends ValueMapping[Id] {
 
 object ComposedMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          country(code: String): Country
-          fx(code: String): Currency
-          countries: [Country!]!
-        }
-        type Currency {
-          code: String!
-          exchangeRate: Float!
-        }
-        type Country {
-          code: String!
-          name: String!
-          currency: Currency!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        country(code: String): Country
+        fx(code: String): Currency
+        countries: [Country!]!
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+      }
+      type Country {
+        code: String!
+        name: String!
+        currency: Currency!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CountryType = schema.ref("Country")

--- a/modules/core/src/test/scala/composed/ComposedListSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedListSpec.scala
@@ -6,9 +6,9 @@ package composed
 import cats.Id
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.mkErrorResult
@@ -26,19 +26,17 @@ object CollectionMapping extends ValueMapping[Id] {
   import CollectionData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          collection: Collection!
-          collections: [Collection!]!
-          collectionByName(name: String!): Collection
-        }
-        type Collection {
-          name: String!
-          itemIds: [String!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        collection: Collection!
+        collections: [Collection!]!
+        collectionByName(name: String!): Collection
+      }
+      type Collection {
+        name: String!
+        itemIds: [String!]!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CollectionType = schema.ref("Collection")
@@ -81,17 +79,15 @@ object ItemMapping extends ValueMapping[Id] {
   import ItemData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          itemById(id: ID!): Item
-        }
-        type Item {
-          id: String!
-          name: String!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        itemById(id: ID!): Item
+      }
+      type Item {
+        id: String!
+        name: String!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val ItemType = schema.ref("Item")
@@ -125,25 +121,23 @@ object ItemMapping extends ValueMapping[Id] {
 
 object ComposedListMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          collection: Collection!
-          collections: [Collection!]!
-          collectionByName(name: String!): Collection
-          itemById(id: ID!): Item
-        }
-        type Collection {
-          name: String!
-          itemIds: [String!]!
-          items: [Item!]!
-        }
-        type Item {
-          id: String!
-          name: String!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        collection: Collection!
+        collections: [Collection!]!
+        collectionByName(name: String!): Collection
+        itemById(id: ID!): Item
+      }
+      type Collection {
+        name: String!
+        itemIds: [String!]!
+        items: [Item!]!
+      }
+      type Item {
+        id: String!
+        name: String!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CollectionType = schema.ref("Collection")

--- a/modules/core/src/test/scala/composed/ComposedSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedSpec.scala
@@ -4,7 +4,7 @@
 package composed
 
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 final class ComposedSpec extends CatsSuite {
   test("simple currency query") {

--- a/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
@@ -6,10 +6,10 @@ package introspection
 import cats.Id
 import cats.tests.CatsSuite
 import io.circe.Json
-import io.circe.literal.JsonStringContext
 import io.circe.optics.JsonPath.root
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import QueryCompiler.IntrospectionLevel
 import IntrospectionLevel._
 
@@ -1295,67 +1295,65 @@ final class IntrospectionSuite extends CatsSuite {
 
 object TestMapping extends Mapping[Id] {
   val schema =
-    Schema(
-      """
-        type Query {
-          users: [User!]!
-        }
+    schema"""
+      type Query {
+        users: [User!]!
+      }
 
-        "User object type"
-        type User implements Profile {
-          id: String
-          name: String
-          age: Int @deprecated(reason: "Use birthday instead")
-          birthday: Date
-        }
+      "User object type"
+      type User implements Profile {
+        id: String
+        name: String
+        age: Int @deprecated(reason: "Use birthday instead")
+        birthday: Date
+      }
 
-        "Profile interface type"
-        interface Profile {
-          id: String
-        }
+      "Profile interface type"
+      interface Profile {
+        id: String
+      }
 
-        "Date object type"
-        type Date {
-          day: Int
-          month: Int
-          year: Int
-        }
+      "Date object type"
+      type Date {
+        day: Int
+        month: Int
+        year: Int
+      }
 
-        "Choice union type"
-        union Choice = User | Date
+      "Choice union type"
+      union Choice = User | Date
 
-        "Flags enum type"
-        enum Flags {
-          A
-          B @deprecated(reason: "Deprecation test")
-          C
-        }
+      "Flags enum type"
+      enum Flags {
+        A
+        B @deprecated(reason: "Deprecation test")
+        C
+      }
 
-        type KindTest {
-          "Scalar field"
-          scalar: Int
-          "Object field"
-          object: User
-          "Interface field"
-          interface: Profile
-          "Union field"
-          union: Choice
-          "Enum field"
-          enum: Flags
-          "List field"
-          list: [Int]
-          "Nonnull field"
-          nonnull: Int!
-          "Nonnull list of nonnull field"
-          nonnulllistnonnull: [Int!]!
-        }
+      type KindTest {
+        "Scalar field"
+        scalar: Int
+        "Object field"
+        object: User
+        "Interface field"
+        interface: Profile
+        "Union field"
+        union: Choice
+        "Enum field"
+        enum: Flags
+        "List field"
+        list: [Int]
+        "Nonnull field"
+        nonnull: Int!
+        "Nonnull list of nonnull field"
+        nonnulllistnonnull: [Int!]!
+      }
 
-        type DeprecationTest {
-          user: User
-          flags: Flags
-        }
-      """
-    ).right.get
+      type DeprecationTest {
+        user: User
+        flags: Flags
+      }
+    """
 
   val typeMappings = Nil
 }
@@ -1374,24 +1372,22 @@ object SmallMapping extends ValueMapping[Id] {
   import SmallData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          users: [User!]!
-          profiles: [Profile!]!
-        }
-        "Profile interface type"
-        interface Profile {
-          id: String
-        }
-        "User object type"
-        type User implements Profile {
-          id: String
-          name: String
-          age: Int
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        users: [User!]!
+        profiles: [Profile!]!
+      }
+      "Profile interface type"
+      interface Profile {
+        id: String
+      }
+      "User object type"
+      type User implements Profile {
+        id: String
+        name: String
+        age: Int
+      }
+    """
 
   val QueryType = schema.queryType
   val UserType = schema.ref("User")

--- a/modules/core/src/test/scala/mapping/MappingValidatorSpec.scala
+++ b/modules/core/src/test/scala/mapping/MappingValidatorSpec.scala
@@ -7,15 +7,16 @@ import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.Mapping
 import cats.Id
 import cats.syntax.all._
-import edu.gemini.grackle.{ ListType, MappingValidator, Schema }
+import edu.gemini.grackle.{ ListType, MappingValidator }
 import edu.gemini.grackle.MappingValidator.ValidationException
+import edu.gemini.grackle.syntax._
 
 final class ValidatorSpec extends AnyFunSuite {
 
   test("missing type mapping") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("type Foo { bar: String }").right.get
+      val schema = schema"type Foo { bar: String }"
       val typeMappings = Nil
     }
 
@@ -30,7 +31,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("missing field mapping") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("type Foo { bar: String }").right.get
+      val schema = schema"type Foo { bar: String }"
       val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
 
@@ -45,7 +46,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("inapplicable type (object mapping for scalar)") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("scalar Foo").right.get
+      val schema = schema"scalar Foo"
       val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
 
@@ -60,7 +61,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("inapplicable type (leaf mapping for object)") {
 
     object M extends Mapping[Id] {
-      val schema =  Schema("type Foo { bar: String }").right.get
+      val schema =  schema"type Foo { bar: String }"
       val typeMappings = List(LeafMapping[String](schema.ref("Foo")))
     }
 
@@ -75,7 +76,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("enums are valid leaf mappings") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("enum Foo { BAR }").right.get
+      val schema = schema"enum Foo { BAR }"
       val typeMappings = List(LeafMapping[String](schema.ref("Foo")))
     }
 
@@ -90,7 +91,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("lists are valid leaf mappings") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("enum Foo { BAR } type Baz { quux: [Foo] }").right.get
+      val schema = schema"enum Foo { BAR } type Baz { quux: [Foo] }"
       val typeMappings = List(
         ObjectMapping(
           schema.ref("Baz"),
@@ -114,7 +115,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("input object types don't require mappings") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("input Foo { bar: String }").right.get
+      val schema = schema"input Foo { bar: String }"
       val typeMappings = Nil
     }
 
@@ -129,7 +130,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("input only enums are valid primitive mappings") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("input Foo { bar: Bar } enum Bar { BAZ }").right.get
+      val schema = schema"input Foo { bar: Bar } enum Bar { BAZ }"
       val typeMappings = List(
         PrimitiveMapping(schema.ref("Bar"))
       )
@@ -147,7 +148,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("nonexistent type (type mapping)") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("").right.get
+      val schema = schema""
       val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
 
@@ -162,7 +163,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("unknown field") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("type Foo { bar: String }").right.get
+      val schema = schema"type Foo { bar: String }"
       val typeMappings = List(
         ObjectMapping(
           schema.ref("Foo"),
@@ -185,7 +186,7 @@ final class ValidatorSpec extends AnyFunSuite {
   test("non-field attributes are valid") {
 
     object M extends Mapping[Id] {
-      val schema = Schema("type Foo { bar: String }").right.get
+      val schema = schema"type Foo { bar: String }"
       val typeMappings = List(
         ObjectMapping(
           schema.ref("Foo"),
@@ -207,7 +208,7 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("unsafeValidate") {
     object M extends Mapping[Id] {
-      val schema = Schema("scalar Bar").right.get
+      val schema = schema"scalar Bar"
       val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
     intercept[ValidationException] {

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -7,6 +7,7 @@ import cats.data.{Ior, NonEmptyChain}
 import cats.data.Ior.Both
 import cats.tests.CatsSuite
 import edu.gemini.grackle.Schema
+import edu.gemini.grackle.syntax._
 
 final class SchemaSpec extends CatsSuite {
   test("schema validation: undefined types: typo in the use of a Query result type") {
@@ -312,7 +313,7 @@ final class SchemaSpec extends CatsSuite {
   test("explicit Schema type (complete)") {
 
     val schema =
-      Schema("""
+      schema"""
 
         schema {
           query: MyQuery
@@ -332,7 +333,7 @@ final class SchemaSpec extends CatsSuite {
           watchFoo: Int
         }
 
-      """).right.get
+      """
 
     assert(schema.queryType                 =:= schema.ref("MyQuery"))
     assert(schema.mutationType.exists(_     =:= schema.ref("MyMutation")))
@@ -343,7 +344,7 @@ final class SchemaSpec extends CatsSuite {
   test("explicit Schema type (partial)") {
 
     val schema =
-      Schema("""
+      schema"""
 
         schema {
           query: MyQuery
@@ -358,7 +359,7 @@ final class SchemaSpec extends CatsSuite {
           setFoo(n: Int): Int
         }
 
-      """).right.get
+      """
 
     assert(schema.queryType             =:= schema.ref("MyQuery"))
     assert(schema.mutationType.exists(_ =:= schema.ref("MyMutation")))
@@ -369,7 +370,7 @@ final class SchemaSpec extends CatsSuite {
   test("implicit Schema type") {
 
     val schema =
-      Schema("""
+      schema"""
 
         type Query {
           foo: Int
@@ -383,7 +384,7 @@ final class SchemaSpec extends CatsSuite {
           watchFoo: Int
         }
 
-      """).right.get
+      """
 
     assert(schema.queryType                 =:= schema.ref("Query"))
     assert(schema.mutationType.exists(_     =:= schema.ref("Mutation")))
@@ -392,7 +393,7 @@ final class SchemaSpec extends CatsSuite {
   }
 
   ignore("no query type (crashes)") {
-    Schema("scalar Foo").right.get.queryType
+    schema"scalar Foo".queryType
   }
 
 }

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -7,6 +7,7 @@ import cats.Id
 import cats.implicits._
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 
 import Query._, Predicate._, Value._
 import QueryCompiler._
@@ -114,41 +115,39 @@ object StarWarsMapping extends ValueMapping[Id] {
   import StarWarsData.{characters, hero, resolveFriends, Character, Droid, Episode, Human}
 
   val schema =
-    Schema(
-      """
-        type Query {
-           hero(episode: Episode!): Character!
-           character(id: ID!): Character
-           human(id: ID!): Human
-           droid(id: ID!): Droid
-         }
-         enum Episode {
-           NEWHOPE
-           EMPIRE
-           JEDI
-         }
-         interface Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-         }
-         type Human implements Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-           homePlanet: String
-         }
-         type Droid implements Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-           primaryFunction: String
-         }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        hero(episode: Episode!): Character!
+        character(id: ID!): Character
+        human(id: ID!): Human
+        droid(id: ID!): Droid
+      }
+      enum Episode {
+        NEWHOPE
+        EMPIRE
+        JEDI
+      }
+      interface Character {
+        id: String!
+        name: String
+        friends: [Character!]
+        appearsIn: [Episode!]
+      }
+      type Human implements Character {
+        id: String!
+        name: String
+        friends: [Character!]
+        appearsIn: [Episode!]
+        homePlanet: String
+      }
+      type Droid implements Character {
+        id: String!
+        name: String
+        friends: [Character!]
+        appearsIn: [Episode!]
+        primaryFunction: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CharacterType = schema.ref("Character")

--- a/modules/core/src/test/scala/starwars/StarWarsSpec.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSpec.scala
@@ -4,7 +4,7 @@
 package starwars
 
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 final class StarWarsSpec extends CatsSuite {
 

--- a/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
@@ -14,10 +14,10 @@ import fs2.Stream
 import edu.gemini.grackle.Query
 import scala.concurrent.ExecutionContext
 import io.circe.Json
-import io.circe.literal._
 import edu.gemini.grackle.QueryCompiler
 import edu.gemini.grackle.Value
 import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.syntax._
 import scala.concurrent.duration._
 
 final class SubscriptionSpec extends CatsSuite {
@@ -29,7 +29,7 @@ final class SubscriptionSpec extends CatsSuite {
     new ValueMapping[IO] {
 
       val schema: Schema =
-        Schema("""
+        schema"""
           type Query {
             get: Int!
           }
@@ -39,7 +39,7 @@ final class SubscriptionSpec extends CatsSuite {
           type Subscription {
             watch: Int!
           }
-        """).right.get
+        """
 
       val QueryType        = schema.ref("Query")
       val MutationType     = schema.ref("Mutation")

--- a/modules/doobie/src/test/scala/coalesce/CoalesceData.scala
+++ b/modules/doobie/src/test/scala/coalesce/CoalesceData.scala
@@ -8,30 +8,29 @@ import _root_.doobie.util.transactor.Transactor
 import cats.effect.Sync
 import edu.gemini.grackle._
 import edu.gemini.grackle.doobie._
+import edu.gemini.grackle.syntax._
 
 trait CoalesceMapping[F[_]] extends DoobieMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          r: [R!]!
-        }
-        type R {
-          id: String!
-          ca: [CA!]!
-          cb: [CB!]!
-        }
-        type CA {
-          id: String!
-          a: Int!
-        }
-        type CB {
-          id: String!
-          b: Boolean!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        r: [R!]!
+      }
+      type R {
+        id: String!
+        ca: [CA!]!
+        cb: [CB!]!
+      }
+      type CA {
+        id: String!
+        a: Int!
+      }
+      type CB {
+        id: String!
+        b: Boolean!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val RType = schema.ref("R")

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -12,6 +12,7 @@ import cats.implicits._
 import edu.gemini.grackle._
 import edu.gemini.grackle.doobie._
 import edu.gemini.grackle.sql.Like
+import edu.gemini.grackle.syntax._
 
 import Query._
 import Predicate._
@@ -40,18 +41,16 @@ class CurrencyMapping[F[_] : Monad] extends ValueMapping[F] {
   import CurrencyData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          allCurrencies: [Currency!]!
-        }
-        type Currency {
-          code: String!
-          exchangeRate: Float!
-          countryCode: String!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        allCurrencies: [Currency!]!
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+        countryCode: String!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CurrencyType = schema.ref("Currency")
@@ -86,45 +85,43 @@ object CurrencyMapping {
 trait WorldMapping[F[_]] extends DoobieMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          cities(namePattern: String = "%"): [City!]
-          country(code: String): Country
-          countries: [Country!]
-        }
-        type City {
-          name: String!
-          country: Country!
-          district: String!
-          population: Int!
-        }
-        type Language {
-          language: String!
-          isOfficial: Boolean!
-          percentage: Float!
-          countries: [Country!]!
-        }
-        type Country {
-          name: String!
-          continent: String!
-          region: String!
-          surfacearea: Float!
-          indepyear: Int
-          population: Int!
-          lifeexpectancy: Float
-          gnp: String
-          gnpold: String
-          localname: String!
-          governmentform: String!
-          headofstate: String
-          capitalId: Int
-          code2: String!
-          cities: [City!]!
-          languages: [Language!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+        countries: [Country!]
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: String
+        gnpold: String
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CountryType = schema.ref("Country")
@@ -203,52 +200,50 @@ object WorldMapping extends DoobieMappingCompanion {
 class ComposedMapping[F[_] : Monad]
   (world: Mapping[F], currency: Mapping[F]) extends Mapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          cities(namePattern: String = "%"): [City!]
-          country(code: String): Country
-          countries: [Country!]
-          currencies: [Currency!]!
-        }
-        type City {
-          name: String!
-          country: Country!
-          district: String!
-          population: Int!
-        }
-        type Language {
-          language: String!
-          isOfficial: Boolean!
-          percentage: Float!
-          countries: [Country!]!
-        }
-        type Currency {
-          code: String!
-          exchangeRate: Float!
-          countryCode: String!
-        }
-        type Country {
-          name: String!
-          continent: String!
-          region: String!
-          surfacearea: Float!
-          indepyear: Int
-          population: Int!
-          lifeexpectancy: Float
-          gnp: String
-          gnpold: String
-          localname: String!
-          governmentform: String!
-          headofstate: String
-          capitalId: Int
-          code2: String!
-          cities: [City!]!
-          languages: [Language!]!
-          currencies: [Currency!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+        countries: [Country!]
+        currencies: [Currency!]!
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+        countryCode: String!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: String
+        gnpold: String
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+        currencies: [Currency!]!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CountryType = schema.ref("Country")

--- a/modules/doobie/src/test/scala/embedding/EmbeddingData.scala
+++ b/modules/doobie/src/test/scala/embedding/EmbeddingData.scala
@@ -6,37 +6,36 @@ package embedding
 import cats.effect.Sync
 import edu.gemini.grackle._
 import edu.gemini.grackle.doobie._
+import edu.gemini.grackle.syntax._
 import _root_.doobie.util.meta.Meta
 import _root_.doobie.util.transactor.Transactor
 
 trait EmbeddingMapping[F[_]] extends DoobieMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          films: [Film!]!
-          series: [Series!]!
-          episodes: [Episode!]!
-        }
-        type Film {
-          title: String!
-          synopses: Synopses!
-        }
-        type Series {
-          title: String!
-          synopses: Synopses!
-          episodes: [Episode!]!
-        }
-        type Episode {
-          title: String!
-          synopses: Synopses!
-        }
-        type Synopses {
-          short: String
-          long: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        films: [Film!]!
+        series: [Series!]!
+        episodes: [Episode!]!
+      }
+      type Film {
+        title: String!
+        synopses: Synopses!
+      }
+      type Series {
+        title: String!
+        synopses: Synopses!
+        episodes: [Episode!]!
+      }
+      type Episode {
+        title: String!
+        synopses: Synopses!
+      }
+      type Synopses {
+        short: String
+        long: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val FilmType = schema.ref("Film")

--- a/modules/doobie/src/test/scala/interfaces/InterfacesData.scala
+++ b/modules/doobie/src/test/scala/interfaces/InterfacesData.scala
@@ -9,50 +9,49 @@ import cats.effect.Sync
 import cats.kernel.Eq
 import edu.gemini.grackle._
 import edu.gemini.grackle.doobie._
+import edu.gemini.grackle.syntax._
 import io.circe.Encoder
 
 trait InterfacesMapping[F[_]] extends DoobieMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          entities: [Entity!]!
-        }
-        interface Entity {
-          id: ID!
-          entityType: EntityType!
-          title: String
-          synopses: Synopses
-        }
-        type Film implements Entity {
-          id: ID!
-          entityType: EntityType!
-          title: String
-          synopses: Synopses
-          rating: String
-        }
-        type Series implements Entity {
-          id: ID!
-          entityType: EntityType!
-          title: String
-          numberOfEpisodes: Int
-          episodes: [Episode!]!
-        }
-        type Episode {
-          id: ID!
-          title: String
-          synopses: Synopses
-        }
-        type Synopses {
-          short: String
-          long: String
-        }
-        enum EntityType {
-          FILM
-          SERIES
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        entities: [Entity!]!
+      }
+      interface Entity {
+        id: ID!
+        entityType: EntityType!
+        title: String
+        synopses: Synopses
+      }
+      type Film implements Entity {
+        id: ID!
+        entityType: EntityType!
+        title: String
+        synopses: Synopses
+        rating: String
+      }
+      type Series implements Entity {
+        id: ID!
+        entityType: EntityType!
+        title: String
+        numberOfEpisodes: Int
+        episodes: [Episode!]!
+      }
+      type Episode {
+        id: ID!
+        title: String
+        synopses: Synopses
+      }
+      type Synopses {
+        short: String
+        long: String
+      }
+      enum EntityType {
+        FILM
+        SERIES
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val EType = schema.ref("Entity")

--- a/modules/doobie/src/test/scala/jsonb/JsonbData.scala
+++ b/modules/doobie/src/test/scala/jsonb/JsonbData.scala
@@ -12,6 +12,7 @@ import cats.effect.Sync
 import cats.implicits._
 import edu.gemini.grackle._
 import edu.gemini.grackle.doobie._
+import edu.gemini.grackle.syntax._
 import io.circe.Json
 
 import Query._
@@ -21,46 +22,44 @@ import QueryCompiler._
 
 trait JsonbMapping[F[_]] extends DoobieMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          record(id: Int!): Row
-          records: [Row!]!
-        }
-        type Row {
-          id: Int!
-          record: Record
-          nonNullRecord: Record!
-        }
-        type Record {
-          bool: Boolean
-          int: Int
-          float: Float
-          string: String
-          id: ID
-          choice: Choice
-          arrary: [Int!]
-          object: A
-          children: [Child!]!
-        }
-        enum Choice {
-          ONE
-          TWO
-          THREE
-        }
-        interface Child {
-          id: ID
-        }
-        type A implements Child {
-          id: ID
-          aField: Int
-        }
-        type B implements Child {
-          id: ID
-          bField: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        record(id: Int!): Row
+        records: [Row!]!
+      }
+      type Row {
+        id: Int!
+        record: Record
+        nonNullRecord: Record!
+      }
+      type Record {
+        bool: Boolean
+        int: Int
+        float: Float
+        string: String
+        id: ID
+        choice: Choice
+        arrary: [Int!]
+        object: A
+        children: [Child!]!
+      }
+      enum Choice {
+        ONE
+        TWO
+        THREE
+      }
+      interface Child {
+        id: ID
+      }
+      type A implements Child {
+        id: ID
+        aField: Int
+      }
+      type B implements Child {
+        id: ID
+        bField: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val RowType = schema.ref("Row")

--- a/modules/doobie/src/test/scala/projection/ProjectionData.scala
+++ b/modules/doobie/src/test/scala/projection/ProjectionData.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import doobie.Transactor
 import doobie.util.meta.Meta
 
-import edu.gemini.grackle._, doobie._
+import edu.gemini.grackle._, doobie._, syntax._
 import edu.gemini.grackle.Predicate.{Const, Eql, FieldPath, Project}
 import edu.gemini.grackle.Query.{Binding, Filter, Select}
 import edu.gemini.grackle.QueryCompiler.SelectElaborator
@@ -17,30 +17,28 @@ import edu.gemini.grackle.Value.{BooleanValue, ObjectValue}
 trait ProjectionMapping[F[_]] extends DoobieMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          level0(filter: Filter): [Level0!]!
-          level1(filter: Filter): [Level1!]!
-          level2(filter: Filter): [Level2!]!
-        }
-        type Level0 {
-          id: String!
-          level1(filter: Filter): [Level1!]!
-        }
-        type Level1 {
-          id: String!
-          level2(filter: Filter): [Level2!]!
-        }
-        type Level2 {
-          id: String!
-          attr: Boolean
-        }
-        input Filter {
-          attr: Boolean
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        level0(filter: Filter): [Level0!]!
+        level1(filter: Filter): [Level1!]!
+        level2(filter: Filter): [Level2!]!
+      }
+      type Level0 {
+        id: String!
+        level1(filter: Filter): [Level1!]!
+      }
+      type Level1 {
+        id: String!
+        level2(filter: Filter): [Level2!]!
+      }
+      type Level2 {
+        id: String!
+        attr: Boolean
+      }
+      input Filter {
+        attr: Boolean
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val Level0Type = schema.ref("Level0")

--- a/modules/doobie/src/test/scala/projection/ProjectionSpec.scala
+++ b/modules/doobie/src/test/scala/projection/ProjectionSpec.scala
@@ -3,7 +3,7 @@
 
 package projection
 
-import io.circe.literal._
+import edu.gemini.grackle.syntax._
 
 import utils.DatabaseSuite
 import grackle.test.SqlProjectionSpec

--- a/modules/doobie/src/test/scala/scalars/MovieData.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieData.scala
@@ -20,6 +20,7 @@ import doobie.Transactor
 import doobie.postgres.implicits._
 import doobie.util.meta.Meta
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import io.circe.Encoder
 
 import doobie._
@@ -105,8 +106,7 @@ trait MovieMapping[F[_]] extends DoobieMapping[F] {
   import MovieData._
 
   val schema =
-    Schema(
-      """
+    schema"""
         type Query {
           movieById(id: UUID!): Movie
           moviesByGenre(genre: Genre!): [Movie!]!
@@ -143,7 +143,6 @@ trait MovieMapping[F[_]] extends DoobieMapping[F] {
           features: [Feature!]!
         }
       """
-    ).right.get
 
   val QueryType = schema.ref("Query")
   val MovieType = schema.ref("Movie")

--- a/modules/doobie/src/test/scala/scalars/MovieSpec.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieSpec.scala
@@ -3,7 +3,7 @@
 
 package scalars
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 import utils.DatabaseSuite
 import grackle.test.SqlMovieSpec
 

--- a/modules/doobie/src/test/scala/unions/UnionsData.scala
+++ b/modules/doobie/src/test/scala/unions/UnionsData.scala
@@ -8,23 +8,22 @@ import _root_.doobie.util.transactor.Transactor
 import cats.effect.Sync
 import edu.gemini.grackle._
 import edu.gemini.grackle.doobie._
+import edu.gemini.grackle.syntax._
 
 trait UnionsMapping[F[_]] extends DoobieMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          collection: [Item!]!
-        }
-        type ItemA {
-          itema: String!
-        }
-        type ItemB {
-          itemb: String!
-        }
-        union Item = ItemA | ItemB
-      """
-    ).right.get
+    schema"""
+      type Query {
+        collection: [Item!]!
+      }
+      type ItemA {
+        itema: String!
+      }
+      type ItemB {
+        itemb: String!
+      }
+      union Item = ItemA | ItemB
+    """
 
   val QueryType = schema.ref("Query")
   val ItemAType = schema.ref("ItemA")

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.sql.Like
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import edu.gemini.grackle.doobie.DoobieMapping
@@ -61,47 +62,45 @@ trait WorldPostgresSchema[F[_]] extends DoobieMapping[F] {
 trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          cities(namePattern: String = "%"): [City!]
-          country(code: String): Country
-          countries(limit: Int = -1, minPopulation: Int = 0, byPopulation: Boolean = false): [Country!]
-          language(language: String): Language
-          search(minPopulation: Int!, indepSince: Int!): [Country!]!
-        }
-        type City {
-          name: String!
-          country: Country!
-          district: String!
-          population: Int!
-        }
-        type Language {
-          language: String!
-          isOfficial: Boolean!
-          percentage: Float!
-          countries: [Country!]!
-        }
-        type Country {
-          name: String!
-          continent: String!
-          region: String!
-          surfacearea: Float!
-          indepyear: Int
-          population: Int!
-          lifeexpectancy: Float
-          gnp: String
-          gnpold: String
-          localname: String!
-          governmentform: String!
-          headofstate: String
-          capitalId: Int
-          code2: String!
-          cities: [City!]!
-          languages: [Language!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+        countries(limit: Int = -1, minPopulation: Int = 0, byPopulation: Boolean = false): [Country!]
+        language(language: String): Language
+        search(minPopulation: Int!, indepSince: Int!): [Country!]!
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: String
+        gnpold: String
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+      }
+    """
 
   val QueryType    = schema.ref("Query")
   val CountryType  = schema.ref("Country")

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -11,7 +11,7 @@ import cats.data.Ior
 import cats.implicits._
 import cats.tests.CatsSuite
 import io.circe.Json
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import Query._, Predicate._, Value._
 import QueryCompiler._
@@ -141,41 +141,39 @@ object StarWarsMapping extends GenericMapping[Id] {
   import StarWarsData.{characters, hero, Droid, Human, Episode}
 
   val schema =
-    Schema(
-      """
-        type Query {
-           hero(episode: Episode!): Character!
-           character(id: ID!): Character
-           human(id: ID!): Human
-           droid(id: ID!): Droid
-         }
-         enum Episode {
-           NEWHOPE
-           EMPIRE
-           JEDI
-         }
-         interface Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-         }
-         type Human implements Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-           homePlanet: String
-         }
-         type Droid implements Character {
-           id: String!
-           name: String
-           friends: [Character!]
-           appearsIn: [Episode!]
-           primaryFunction: String
-         }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        hero(episode: Episode!): Character!
+        character(id: ID!): Character
+        human(id: ID!): Human
+        droid(id: ID!): Droid
+      }
+      enum Episode {
+        NEWHOPE
+        EMPIRE
+        JEDI
+      }
+      interface Character {
+        id: String!
+        name: String
+        friends: [Character!]
+        appearsIn: [Episode!]
+      }
+      type Human implements Character {
+        id: String!
+        name: String
+        friends: [Character!]
+        appearsIn: [Episode!]
+        homePlanet: String
+      }
+      type Droid implements Character {
+        id: String!
+        name: String
+        friends: [Character!]
+        appearsIn: [Episode!]
+        primaryFunction: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val EpisodeType = schema.ref("Episode")

--- a/modules/generic/src/test/scala/recursion.scala
+++ b/modules/generic/src/test/scala/recursion.scala
@@ -7,12 +7,12 @@ package generic
 import cats.Id
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.mkOneError
 import semiauto._
+import edu.gemini.grackle.syntax._
 
 object MutualRecursionData {
   import MutualRecursionMapping._
@@ -51,22 +51,20 @@ object MutualRecursionMapping extends GenericMapping[Id] {
   import MutualRecursionData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-           programmeById(id: ID!): Programme
-           productionById(id: ID!): Production
-         }
-         type Programme {
-           id: String!
-           productions: [Production!]
-         }
-         type Production {
-           id: String!
-           programme: Programme!
-         }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        programmeById(id: ID!): Programme
+        productionById(id: ID!): Production
+      }
+      type Programme {
+        id: String!
+        productions: [Production!]
+      }
+      type Production {
+        id: String!
+        programme: Programme!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val ProgrammeType = schema.ref("Programme")

--- a/modules/generic/src/test/scala/scalars.scala
+++ b/modules/generic/src/test/scala/scalars.scala
@@ -12,9 +12,9 @@ import cats.{Eq, Id, Order}
 import cats.implicits._
 import cats.tests.CatsSuite
 import io.circe.Encoder
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import semiauto._
@@ -97,37 +97,35 @@ object MovieMapping extends GenericMapping[Id] {
   import MovieData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          movieById(id: UUID!): Movie
-          moviesByGenre(genre: Genre!): [Movie!]!
-          moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
-          moviesLongerThan(duration: Interval!): [Movie!]!
-          moviesShownLaterThan(time: Time!): [Movie!]!
-          moviesShownBetween(from: DateTime!, to: DateTime!): [Movie!]!
-        }
-        scalar UUID
-        scalar Time
-        scalar Date
-        scalar DateTime
-        scalar Interval
-        enum Genre {
-          DRAMA
-          ACTION
-          COMEDY
-        }
-        type Movie {
-          id: UUID!
-          title: String!
-          genre: Genre!
-          releaseDate: Date!
-          showTime: Time!
-          nextShowing: DateTime!
-          duration: Interval!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        movieById(id: UUID!): Movie
+        moviesByGenre(genre: Genre!): [Movie!]!
+        moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
+        moviesLongerThan(duration: Interval!): [Movie!]!
+        moviesShownLaterThan(time: Time!): [Movie!]!
+        moviesShownBetween(from: DateTime!, to: DateTime!): [Movie!]!
+      }
+      scalar UUID
+      scalar Time
+      scalar Date
+      scalar DateTime
+      scalar Interval
+      enum Genre {
+        DRAMA
+        ACTION
+        COMEDY
+      }
+      type Movie {
+        id: UUID!
+        title: String!
+        genre: Genre!
+        releaseDate: Date!
+        showTime: Time!
+        nextShowing: DateTime!
+        duration: Interval!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val MovieType = schema.ref("Movie")

--- a/modules/skunk/src/test/scala/coalesce/CoalesceData.scala
+++ b/modules/skunk/src/test/scala/coalesce/CoalesceData.scala
@@ -5,7 +5,7 @@ package coalesce
 
 import cats.effect.Sync
 
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import _root_.skunk.codec.all._
 import cats.effect.Resource
 import _root_.skunk.Session
@@ -13,26 +13,24 @@ import _root_.skunk.Session
 trait CoalesceMapping[F[_]] extends SkunkMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          r: [R!]!
-        }
-        type R {
-          id: String!
-          ca: [CA!]!
-          cb: [CB!]!
-        }
-        type CA {
-          id: String!
-          a: Int!
-        }
-        type CB {
-          id: String!
-          b: Boolean!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        r: [R!]!
+      }
+      type R {
+        id: String!
+        ca: [CA!]!
+        cb: [CB!]!
+      }
+      type CA {
+        id: String!
+        a: Int!
+      }
+      type CB {
+        id: String!
+        b: Boolean!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val RType = schema.ref("R")

--- a/modules/skunk/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/skunk/src/test/scala/composed/ComposedWorldData.scala
@@ -8,7 +8,7 @@ import cats.data.Ior
 import cats.effect.Sync
 import cats.implicits._
 
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import edu.gemini.grackle.sql.Like
 import Query._, Predicate._, Value._
 import QueryCompiler._
@@ -38,18 +38,16 @@ class CurrencyMapping[F[_] : Monad] extends ValueMapping[F] {
   import CurrencyData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          allCurrencies: [Currency!]!
-        }
-        type Currency {
-          code: String!
-          exchangeRate: Float!
-          countryCode: String!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        allCurrencies: [Currency!]!
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+        countryCode: String!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CurrencyType = schema.ref("Currency")
@@ -84,45 +82,43 @@ object CurrencyMapping {
 trait WorldMapping[F[_]] extends SkunkMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          cities(namePattern: String = "%"): [City!]
-          country(code: String): Country
-          countries: [Country!]
-        }
-        type City {
-          name: String!
-          country: Country!
-          district: String!
-          population: Int!
-        }
-        type Language {
-          language: String!
-          isOfficial: Boolean!
-          percentage: Float!
-          countries: [Country!]!
-        }
-        type Country {
-          name: String!
-          continent: String!
-          region: String!
-          surfacearea: Float!
-          indepyear: Int
-          population: Int!
-          lifeexpectancy: Float
-          gnp: String
-          gnpold: String
-          localname: String!
-          governmentform: String!
-          headofstate: String
-          capitalId: Int
-          code2: String!
-          cities: [City!]!
-          languages: [Language!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+        countries: [Country!]
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: String
+        gnpold: String
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CountryType = schema.ref("Country")
@@ -201,52 +197,50 @@ object WorldMapping extends SkunkMappingCompanion {
 class ComposedMapping[F[_] : Monad]
   (world: Mapping[F], currency: Mapping[F]) extends Mapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          cities(namePattern: String = "%"): [City!]
-          country(code: String): Country
-          countries: [Country!]
-          currencies: [Currency!]!
-        }
-        type City {
-          name: String!
-          country: Country!
-          district: String!
-          population: Int!
-        }
-        type Language {
-          language: String!
-          isOfficial: Boolean!
-          percentage: Float!
-          countries: [Country!]!
-        }
-        type Currency {
-          code: String!
-          exchangeRate: Float!
-          countryCode: String!
-        }
-        type Country {
-          name: String!
-          continent: String!
-          region: String!
-          surfacearea: Float!
-          indepyear: Int
-          population: Int!
-          lifeexpectancy: Float
-          gnp: String
-          gnpold: String
-          localname: String!
-          governmentform: String!
-          headofstate: String
-          capitalId: Int
-          code2: String!
-          cities: [City!]!
-          languages: [Language!]!
-          currencies: [Currency!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+        countries: [Country!]
+        currencies: [Currency!]!
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+        countryCode: String!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: String
+        gnpold: String
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+        currencies: [Currency!]!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val CountryType = schema.ref("Country")

--- a/modules/skunk/src/test/scala/embedding/EmbeddingData.scala
+++ b/modules/skunk/src/test/scala/embedding/EmbeddingData.scala
@@ -5,38 +5,36 @@ package embedding
 
 import cats.effect.Sync
 import  _root_.skunk.codec.all._
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import cats.effect.Resource
 import _root_.skunk.Session
 
 trait EmbeddingMapping[F[_]] extends SkunkMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          films: [Film!]!
-          series: [Series!]!
-          episodes: [Episode!]!
-        }
-        type Film {
-          title: String!
-          synopses: Synopses!
-        }
-        type Series {
-          title: String!
-          synopses: Synopses!
-          episodes: [Episode!]!
-        }
-        type Episode {
-          title: String!
-          synopses: Synopses!
-        }
-        type Synopses {
-          short: String
-          long: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        films: [Film!]!
+        series: [Series!]!
+        episodes: [Episode!]!
+      }
+      type Film {
+        title: String!
+        synopses: Synopses!
+      }
+      type Series {
+        title: String!
+        synopses: Synopses!
+        episodes: [Episode!]!
+      }
+      type Episode {
+        title: String!
+        synopses: Synopses!
+      }
+      type Synopses {
+        short: String
+        long: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val FilmType = schema.ref("Film")

--- a/modules/skunk/src/test/scala/interfaces/InterfacesData.scala
+++ b/modules/skunk/src/test/scala/interfaces/InterfacesData.scala
@@ -8,53 +8,51 @@ import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe.Encoder
 import _root_.skunk.codec.all._
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import _root_.skunk.Codec
 import cats.effect.Resource
 import _root_.skunk.Session
 
 trait InterfacesMapping[F[_]] extends SkunkMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          entities: [Entity!]!
-        }
-        interface Entity {
-          id: ID!
-          entityType: EntityType!
-          title: String
-          synopses: Synopses
-        }
-        type Film implements Entity {
-          id: ID!
-          entityType: EntityType!
-          title: String
-          synopses: Synopses
-          rating: String
-        }
-        type Series implements Entity {
-          id: ID!
-          entityType: EntityType!
-          title: String
-          numberOfEpisodes: Int
-          episodes: [Episode!]!
-        }
-        type Episode {
-          id: ID!
-          title: String
-          synopses: Synopses
-        }
-        type Synopses {
-          short: String
-          long: String
-        }
-        enum EntityType {
-          FILM
-          SERIES
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        entities: [Entity!]!
+      }
+      interface Entity {
+        id: ID!
+        entityType: EntityType!
+        title: String
+        synopses: Synopses
+      }
+      type Film implements Entity {
+        id: ID!
+        entityType: EntityType!
+        title: String
+        synopses: Synopses
+        rating: String
+      }
+      type Series implements Entity {
+        id: ID!
+        entityType: EntityType!
+        title: String
+        numberOfEpisodes: Int
+        episodes: [Episode!]!
+      }
+      type Episode {
+        id: ID!
+        title: String
+        synopses: Synopses
+      }
+      type Synopses {
+        short: String
+        long: String
+      }
+      enum EntityType {
+        FILM
+        SERIES
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val EType = schema.ref("Entity")

--- a/modules/skunk/src/test/scala/jsonb/JsonbData.scala
+++ b/modules/skunk/src/test/scala/jsonb/JsonbData.scala
@@ -6,7 +6,7 @@ package jsonb
 import cats.effect.Sync
 import cats.implicits._
 
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import _root_.skunk.codec.all._
@@ -16,46 +16,44 @@ import _root_.skunk.Session
 
 trait JsonbMapping[F[_]] extends SkunkMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          record(id: Int!): Row
-          records: [Row!]!
-        }
-        type Row {
-          id: Int!
-          record: Record
-          nonNullRecord: Record!
-        }
-        type Record {
-          bool: Boolean
-          int: Int
-          float: Float
-          string: String
-          id: ID
-          choice: Choice
-          arrary: [Int!]
-          object: A
-          children: [Child!]!
-        }
-        enum Choice {
-          ONE
-          TWO
-          THREE
-        }
-        interface Child {
-          id: ID
-        }
-        type A implements Child {
-          id: ID
-          aField: Int
-        }
-        type B implements Child {
-          id: ID
-          bField: String
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        record(id: Int!): Row
+        records: [Row!]!
+      }
+      type Row {
+        id: Int!
+        record: Record
+        nonNullRecord: Record!
+      }
+      type Record {
+        bool: Boolean
+        int: Int
+        float: Float
+        string: String
+        id: ID
+        choice: Choice
+        arrary: [Int!]
+        object: A
+        children: [Child!]!
+      }
+      enum Choice {
+        ONE
+        TWO
+        THREE
+      }
+      interface Child {
+        id: ID
+      }
+      type A implements Child {
+        id: ID
+        aField: Int
+      }
+      type B implements Child {
+        id: ID
+        bField: String
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val RowType = schema.ref("Row")

--- a/modules/skunk/src/test/scala/mapping/SqlMappingValidatorSpec.scala
+++ b/modules/skunk/src/test/scala/mapping/SqlMappingValidatorSpec.scala
@@ -4,7 +4,7 @@
 package validator
 
 import cats.effect.IO
-import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import edu.gemini.grackle.skunk.SkunkMapping
 import edu.gemini.grackle.skunk.SkunkMonitor
 import org.scalatest.funsuite.AnyFunSuite
@@ -15,7 +15,7 @@ final class SqlMappingValidatorSpec extends AnyFunSuite {
   abstract class BaseTestMapping extends SkunkMapping[IO](null, SkunkMonitor.noopMonitor)
 
   object M extends BaseTestMapping {
-    val schema = Schema("type Foo { bar: Baz }, scalar Baz").right.get
+    val schema = schema"type Foo { bar: Baz }, scalar Baz"
     val typeMappings: List[TypeMapping] =
     List(
       ObjectMapping(

--- a/modules/skunk/src/test/scala/projection/ProjectionData.scala
+++ b/modules/skunk/src/test/scala/projection/ProjectionData.scala
@@ -6,7 +6,7 @@ package projection
 import cats.effect.Sync
 import cats.implicits._
 
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import edu.gemini.grackle.Predicate.{Const, Eql, FieldPath, Project}
 import edu.gemini.grackle.Query.{Binding, Filter, Select}
 import edu.gemini.grackle.QueryCompiler.SelectElaborator
@@ -18,30 +18,28 @@ import _root_.skunk.codec.all._
 trait ProjectionMapping[F[_]] extends SkunkMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          level0(filter: Filter): [Level0!]!
-          level1(filter: Filter): [Level1!]!
-          level2(filter: Filter): [Level2!]!
-        }
-        type Level0 {
-          id: String!
-          level1(filter: Filter): [Level1!]!
-        }
-        type Level1 {
-          id: String!
-          level2(filter: Filter): [Level2!]!
-        }
-        type Level2 {
-          id: String!
-          attr: Boolean
-        }
-        input Filter {
-          attr: Boolean
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        level0(filter: Filter): [Level0!]!
+        level1(filter: Filter): [Level1!]!
+        level2(filter: Filter): [Level2!]!
+      }
+      type Level0 {
+        id: String!
+        level1(filter: Filter): [Level1!]!
+      }
+      type Level1 {
+        id: String!
+        level2(filter: Filter): [Level2!]!
+      }
+      type Level2 {
+        id: String!
+        attr: Boolean
+      }
+      input Filter {
+        attr: Boolean
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val Level0Type = schema.ref("Level0")

--- a/modules/skunk/src/test/scala/scalars/MovieData.scala
+++ b/modules/skunk/src/test/scala/scalars/MovieData.scala
@@ -15,6 +15,7 @@ import cats.syntax.all._
 import io.circe.Encoder
 
 import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import _root_.skunk.Codec
@@ -104,45 +105,43 @@ trait MovieMapping[F[_]] extends SkunkMapping[F] {
   import MovieData._
 
   val schema =
-    Schema(
-      """
-        type Query {
-          movieById(id: UUID!): Movie
-          moviesByGenre(genre: Genre!): [Movie!]!
-          moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
-          moviesLongerThan(duration: Interval!): [Movie!]!
-          moviesShownLaterThan(time: Time!): [Movie!]!
-          moviesShownBetween(from: DateTime!, to: DateTime!): [Movie!]!
-          longMovies: [Movie!]!
-        }
-        scalar UUID
-        scalar Time
-        scalar Date
-        scalar DateTime
-        scalar Interval
-        enum Genre {
-          DRAMA
-          ACTION
-          COMEDY
-        }
-        enum Feature {
-          HD
-          HLS
-        }
-        type Movie {
-          id: UUID!
-          title: String!
-          genre: Genre!
-          releaseDate: Date!
-          showTime: Time!
-          nextShowing: DateTime!
-          nextEnding: DateTime!
-          duration: Interval!
-          categories: [String!]!
-          features: [Feature!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        movieById(id: UUID!): Movie
+        moviesByGenre(genre: Genre!): [Movie!]!
+        moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
+        moviesLongerThan(duration: Interval!): [Movie!]!
+        moviesShownLaterThan(time: Time!): [Movie!]!
+        moviesShownBetween(from: DateTime!, to: DateTime!): [Movie!]!
+        longMovies: [Movie!]!
+      }
+      scalar UUID
+      scalar Time
+      scalar Date
+      scalar DateTime
+      scalar Interval
+      enum Genre {
+        DRAMA
+        ACTION
+        COMEDY
+      }
+      enum Feature {
+        HD
+        HLS
+      }
+      type Movie {
+        id: UUID!
+        title: String!
+        genre: Genre!
+        releaseDate: Date!
+        showTime: Time!
+        nextShowing: DateTime!
+        nextEnding: DateTime!
+        duration: Interval!
+        categories: [String!]!
+        features: [Feature!]!
+      }
+    """
 
   val QueryType = schema.ref("Query")
   val MovieType = schema.ref("Movie")

--- a/modules/skunk/src/test/scala/subscription/SubscriptionData.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionData.scala
@@ -9,6 +9,7 @@ import _root_.skunk.Session
 import cats.effect.{ Bracket, Resource, Sync }
 import cats.syntax.all._
 import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
 import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query._
 import edu.gemini.grackle.QueryCompiler._
@@ -18,25 +19,23 @@ import edu.gemini.grackle.Value._
 trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          city(id: Int!): City
-        }
-        type Subscription {
-          channel: City!
-        }
-        type City {
-          name: String!
-          country: Country!
-          population: Int!
-        }
-        type Country {
-          name: String!
-          cities: [City!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        city(id: Int!): City
+      }
+      type Subscription {
+        channel: City!
+      }
+      type City {
+        name: String!
+        country: Country!
+        population: Int!
+      }
+      type Country {
+        name: String!
+        cities: [City!]!
+      }
+    """
 
   class TableDef(name: String) {
     def col(colName: String, codec: Codec[_]): ColumnRef =

--- a/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionSpec.scala
@@ -4,7 +4,7 @@
 package subscription
 
 import utils.DatabaseSuite
-import io.circe.literal._
+import edu.gemini.grackle.syntax._
 import io.circe.Json
 import cats.effect.IO
 import skunk.implicits._

--- a/modules/skunk/src/test/scala/unions/UnionsData.scala
+++ b/modules/skunk/src/test/scala/unions/UnionsData.scala
@@ -5,26 +5,24 @@ package unions
 
 import cats.effect.Sync
 import _root_.skunk.codec.all._
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import cats.effect.Resource
 import _root_.skunk.Session
 
 trait UnionsMapping[F[_]] extends SkunkMapping[F] {
   val schema =
-    Schema(
-      """
-        type Query {
-          collection: [Item!]!
-        }
-        type ItemA {
-          itema: String!
-        }
-        type ItemB {
-          itemb: String!
-        }
-        union Item = ItemA | ItemB
-      """
-    ).right.get
+    schema"""
+      type Query {
+        collection: [Item!]!
+      }
+      type ItemA {
+        itema: String!
+      }
+      type ItemB {
+        itemb: String!
+      }
+      union Item = ItemA | ItemB
+    """
 
   val QueryType = schema.ref("Query")
   val ItemAType = schema.ref("ItemA")

--- a/modules/skunk/src/test/scala/world/WorldData.scala
+++ b/modules/skunk/src/test/scala/world/WorldData.scala
@@ -6,7 +6,7 @@ package world
 import cats.effect.Sync
 import cats.implicits._
 
-import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle._, skunk._, syntax._
 import edu.gemini.grackle.sql.Like
 import Query._, Predicate._, Value._
 import QueryCompiler._
@@ -61,47 +61,45 @@ trait WorldPostgresSchema[F[_]] extends SkunkMapping[F] {
 trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          cities(namePattern: String = "%"): [City!]
-          country(code: String): Country
-          countries(limit: Int = -1, minPopulation: Int = 0, byPopulation: Boolean = false): [Country!]
-          language(language: String): Language
-          search(minPopulation: Int!, indepSince: Int!): [Country!]!
-        }
-        type City {
-          name: String!
-          country: Country!
-          district: String!
-          population: Int!
-        }
-        type Language {
-          language: String!
-          isOfficial: Boolean!
-          percentage: Float!
-          countries: [Country!]!
-        }
-        type Country {
-          name: String!
-          continent: String!
-          region: String!
-          surfacearea: Float!
-          indepyear: Int
-          population: Int!
-          lifeexpectancy: Float
-          gnp: String
-          gnpold: String
-          localname: String!
-          governmentform: String!
-          headofstate: String
-          capitalId: Int
-          code2: String!
-          cities: [City!]!
-          languages: [Language!]!
-        }
-      """
-    ).right.get
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+        countries(limit: Int = -1, minPopulation: Int = 0, byPopulation: Boolean = false): [Country!]
+        language(language: String): Language
+        search(minPopulation: Int!, indepSince: Int!): [Country!]!
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: String
+        gnpold: String
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+      }
+    """
 
   val QueryType    = schema.ref("Query")
   val CountryType  = schema.ref("Country")

--- a/modules/sql/src/test/scala/SqlCoalesceSpec.scala
+++ b/modules/sql/src/test/scala/SqlCoalesceSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor
 import cats.effect.IO

--- a/modules/sql/src/test/scala/SqlComposedWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlComposedWorldSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor

--- a/modules/sql/src/test/scala/SqlEmbeddingSpec.scala
+++ b/modules/sql/src/test/scala/SqlEmbeddingSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor

--- a/modules/sql/src/test/scala/SqlInterfacesSpec.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor

--- a/modules/sql/src/test/scala/SqlJsonbSpec.scala
+++ b/modules/sql/src/test/scala/SqlJsonbSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor

--- a/modules/sql/src/test/scala/SqlMovieSpec.scala
+++ b/modules/sql/src/test/scala/SqlMovieSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor

--- a/modules/sql/src/test/scala/SqlMutationSpec.scala
+++ b/modules/sql/src/test/scala/SqlMutationSpec.scala
@@ -7,36 +7,33 @@ import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor
 import cats.effect.IO
 import io.circe.Json
-import io.circe.literal._
-import edu.gemini.grackle.Schema
+import edu.gemini.grackle.syntax._
 
 trait SqlMutationSchema {
 
   val schema =
-    Schema(
-      """
-        type Query {
-          city(id: Int!): City
-        }
-        type Mutation {
-          updatePopulation(id: Int!, population: Int!): City
-          createCity(
-            name: String!
-            countryCode: String!
-            population: Int!
-          ): City
-        }
-        type City {
+    schema"""
+      type Query {
+        city(id: Int!): City
+      }
+      type Mutation {
+        updatePopulation(id: Int!, population: Int!): City
+        createCity(
           name: String!
-          country: Country!
+          countryCode: String!
           population: Int!
-        }
-        type Country {
-          name: String!
-          cities: [City!]!
-        }
-      """
-    ).right.get
+        ): City
+      }
+      type City {
+        name: String!
+        country: Country!
+        population: Int!
+      }
+      type Country {
+        name: String!
+        cities: [City!]!
+      }
+    """
 
 }
 

--- a/modules/sql/src/test/scala/SqlProjectionSpec.scala
+++ b/modules/sql/src/test/scala/SqlProjectionSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor

--- a/modules/sql/src/test/scala/SqlUnionSpec.scala
+++ b/modules/sql/src/test/scala/SqlUnionSpec.scala
@@ -6,7 +6,7 @@ package grackle.test
 import cats.effect.IO
 import edu.gemini.grackle.QueryExecutor
 import io.circe.Json
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 import org.scalatest.funsuite.AnyFunSuite
 
 trait SqlUnionSpec extends AnyFunSuite {

--- a/modules/sql/src/test/scala/SqlWorldCompilerSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldCompilerSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor
 import cats.effect.IO

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -3,7 +3,7 @@
 
 package grackle.test
 
-import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.syntax._
 import io.circe.optics.JsonPath.root
 import org.scalatest.funsuite.AnyFunSuite
 import edu.gemini.grackle.QueryExecutor


### PR DESCRIPTION
This adds schema and json literals, the former for convenience and the latter to insulate us from a potentially drawn-out effort to get Circe literals into Scala 3.

Error reporting for schemas is bad because the parser errors are bad, and also because failure is Json blobs all the way down so there's no general way to pull out text messages, although knowing how it's implemented we could probably hack something up. Suggestions wanted here.

I only changed one of the tests to use the new literals, just to show that it works. Once we agree this is all ok I can change the rest and remove the circe-literal dependency.