### PR TITLE
add structured Problem type

### DIFF
--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -7,6 +7,7 @@ import cats.Monad
 import cats.data.{ Ior, IorT }
 import cats.implicits._
 import io.circe.{Encoder, Json}
+import io.circe.syntax._
 import org.tpolecat.typename._
 import org.tpolecat.sourcepos.SourcePos
 
@@ -50,8 +51,8 @@ abstract class Mapping[F[_]](implicit val M: Monad[F]) extends QueryExecutor[F, 
   ): F[Json] =
     compileAndRunAll(text, name, untypedVars, introspectionLevel, env).compile.toList.map {
       case List(j) => j
-      case Nil     => QueryInterpreter.mkError("Result stream was empty.")
-      case js      => QueryInterpreter.mkError(s"Result stream contained ${js.length} results; expected exactly one.")
+      case Nil     => QueryInterpreter.mkError("Result stream was empty.").asJson
+      case js      => QueryInterpreter.mkError(s"Result stream contained ${js.length} results; expected exactly one.").asJson
     }
 
   def compileAndRunAll(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): Stream[F,Json] =

--- a/modules/core/src/main/scala/package.scala
+++ b/modules/core/src/main/scala/package.scala
@@ -4,7 +4,6 @@
 package edu.gemini
 
 import cats.data.IorNec
-import io.circe.Json
 import cats.data.Ior
 import cats.data.NonEmptyChain
 
@@ -15,7 +14,7 @@ package object grackle {
    * A result of type `T`, a non-empty collection of errors encoded as
    * Json, or both.
    */
-  type Result[+T] = IorNec[Json, T]
+  type Result[+T] = IorNec[Problem, T]
 
   object Result {
 
@@ -25,10 +24,10 @@ package object grackle {
     def apply[A](a: A): Result[A] = Ior.right(a)
 
     def failure[A](s: String): Result[A] =
-      failure(Json.fromString(s))
+      failure(Problem(s))
 
-    def failure[A](j: Json): Result[A] =
-      Ior.left(NonEmptyChain(j))
+    def failure[A](p: Problem): Result[A] =
+      Ior.left(NonEmptyChain(p))
 
   }
 

--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+
+import io.circe._
+import io.circe.syntax._
+
+/** A problem, to be reported back to the user. */
+final case class Problem(
+  message: String,
+  locations: List[(Int, Int)] = Nil,
+  path: List[String] = Nil
+)
+
+object Problem {
+
+  implicit val ProblemEncoder: Encoder[Problem] = { p =>
+
+    val locationsField: List[(String, Json)] =
+      if (p.locations.isEmpty) Nil
+      else List(
+        "locations" ->
+          p.locations.map { case (line, col) =>
+            Json.obj(
+              "line" -> line.asJson,
+              "col"  -> col.asJson
+            )
+          } .asJson
+      )
+
+    val pathField: List[(String, Json)] =
+      if (p.path.isEmpty) Nil
+      else List(("path" -> p.path.asJson))
+
+    Json.fromFields(
+      "message" -> p.message.asJson ::
+      locationsField                :::
+      pathField
+    )
+
+  }
+
+}

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -991,7 +991,7 @@ object SchemaValidator {
     errors.map(undefinedResults.addLeft(_)).getOrElse(undefinedResults)
   }
 
-  def validateImpls(definitions: List[TypeDefinition]): List[Json] = {
+  def validateImpls(definitions: List[TypeDefinition]): List[Problem] = {
     val interfaces = definitions.collect {
       case a: InterfaceTypeDefinition => a
     }
@@ -1020,7 +1020,7 @@ object SchemaValidator {
     interfaceErrors ++ objectErrors
   }
 
-  def checkImplementation(name: Ast.Name, implementorFields: List[Ast.FieldDefinition], interface: InterfaceTypeDefinition): List[Json] = {
+  def checkImplementation(name: Ast.Name, implementorFields: List[Ast.FieldDefinition], interface: InterfaceTypeDefinition): List[Problem] = {
     interface.fields.flatMap { ifaceField =>
       implementorFields.find(_.name == ifaceField.name).map { matching =>
         if (ifaceField.tpe != matching.tpe) {
@@ -1038,7 +1038,7 @@ object SchemaValidator {
     arg.name == implArg.name && arg.tpe == implArg.tpe
   }
 
-  def checkForEnumValueDuplicates(definitions: List[TypeDefinition]): List[Json] =
+  def checkForEnumValueDuplicates(definitions: List[TypeDefinition]): List[Problem] =
   {
     val enums = definitions.collect[EnumTypeDefinition] {
       case a: EnumTypeDefinition => a

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -7,8 +7,6 @@ import cats.Id
 import cats.data.{Chain, Ior}
 import cats.implicits._
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
-
 import edu.gemini.grackle._
 import Query._, Predicate._, Value._, UntypedOperation._
 import QueryCompiler._, ComponentElaborator.TrivialJoin
@@ -220,11 +218,7 @@ final class CompilerSuite extends CatsSuite {
       }
     """
 
-    val expected = json"""
-      {
-        "message" : "Non-leaf field 'character' of Query must have a non-empty subselection set"
-      }
-    """
+    val expected = Problem("Non-leaf field 'character' of Query must have a non-empty subselection set")
 
     val res = AtomicMapping.compiler.compile(query)
 
@@ -240,11 +234,7 @@ final class CompilerSuite extends CatsSuite {
       }
     """
 
-    val expected = json"""
-      {
-        "message" : "Unknown field 'foo' in select"
-      }
-    """
+    val expected = Problem("Unknown field 'foo' in select")
 
     val res = AtomicMapping.compiler.compile(query)
 
@@ -262,11 +252,7 @@ final class CompilerSuite extends CatsSuite {
       }
     """
 
-    val expected = json"""
-      {
-        "message" : "Leaf field 'name' of Character must have an empty subselection set"
-      }
-    """
+    val expected = Problem("Leaf field 'name' of Character must have an empty subselection set")
 
     val res = AtomicMapping.compiler.compile(query)
 
@@ -284,11 +270,7 @@ final class CompilerSuite extends CatsSuite {
       }
     """
 
-    val expected = json"""
-      {
-        "message" : "Leaf field 'name' of Character must have an empty subselection set"
-      }
-    """
+    val expected = Problem("Leaf field 'name' of Character must have an empty subselection set")
 
     val res = AtomicMapping.compiler.compile(query)
 
@@ -304,11 +286,7 @@ final class CompilerSuite extends CatsSuite {
       }
     """
 
-    val expected = json"""
-      {
-        "message" : "Unknown argument(s) 'quux' in field character of type Query"
-      }
-    """
+    val expected = Problem("Unknown argument(s) 'quux' in field character of type Query")
 
     val res = AtomicMapping.compiler.compile(query)
 

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -6,7 +6,6 @@ package compiler
 import cats.Id
 import cats.data.{Chain, Ior}
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
 
 import edu.gemini.grackle._
 import Query._, Value._
@@ -104,12 +103,7 @@ final class InputValuesSuite extends CatsSuite {
       }
     """
 
-    val expected =
-      json"""
-        {
-          "message" : "Unknown field(s) 'wibble' in input object value of type InObj"
-        }
-      """
+    val expected = Problem("Unknown field(s) 'wibble' in input object value of type InObj")
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)

--- a/modules/core/src/test/scala/compiler/ProblemSpec.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSpec.scala
@@ -1,0 +1,86 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import cats.tests.CatsSuite
+import io.circe.literal.JsonStringContext
+import edu.gemini.grackle.Problem
+import io.circe.syntax._
+import io.circe.literal._
+
+final class ProblemSpec extends CatsSuite {
+
+  test("encoding (full)") {
+    assert(
+      Problem("foo", List(1 -> 2, 5 -> 6), List("bar", "baz")).asJson ==
+      json"""
+        {
+          "message" : "foo",
+          "locations" : [
+            {
+              "line" : 1,
+              "col" : 2
+            },
+            {
+              "line" : 5,
+              "col" : 6
+            }
+          ],
+          "path" : [
+            "bar",
+            "baz"
+          ]
+        }
+      """
+    )
+  }
+
+  test("encoding (no path)") {
+    assert(
+      Problem("foo", List(1 -> 2, 5 -> 6), Nil).asJson ==
+      json"""
+        {
+          "message" : "foo",
+          "locations" : [
+            {
+              "line" : 1,
+              "col" : 2
+            },
+            {
+              "line" : 5,
+              "col" : 6
+            }
+          ]
+        }
+      """
+    )
+  }
+
+  test("encoding (no locations)") {
+    assert(
+      Problem("foo", Nil, List("bar", "baz")).asJson ==
+      json"""
+        {
+          "message" : "foo",
+          "path" : [
+            "bar",
+            "baz"
+          ]
+        }
+      """
+    )
+  }
+
+  test("encoding (message only)") {
+    assert(
+      Problem("foo", Nil, Nil).asJson ==
+      json"""
+        {
+          "message" : "foo"
+        }
+      """
+    )
+  }
+
+}

--- a/modules/core/src/test/scala/compiler/QuerySizeSpec.scala
+++ b/modules/core/src/test/scala/compiler/QuerySizeSpec.scala
@@ -5,8 +5,7 @@ package compiler
 
 import cats.data.{Chain, Ior}
 import cats.tests.CatsSuite
-import io.circe.literal.JsonStringContext
-
+import edu.gemini.grackle.Problem
 import starwars.StarWarsMapping
 
 class QuerySizeSpec extends CatsSuite {
@@ -204,12 +203,7 @@ class QuerySizeSpec extends CatsSuite {
       }
     """
 
-    val expected =
-      json"""
-        {
-          "message" : "Query is too deep: depth is 8 levels, maximum is 5"
-        }
-      """
+    val expected = Problem("Query is too deep: depth is 8 levels, maximum is 5")
 
     val res = StarWarsMapping.compiler.compile(query)
     assert(res == Ior.Left(Chain(expected)))
@@ -234,12 +228,7 @@ class QuerySizeSpec extends CatsSuite {
     """
 
 
-    val expected =
-      json"""
-        {
-          "message" : "Query is too wide: width is 6 leaves, maximum is 5"
-        }
-      """
+    val expected = Problem("Query is too wide: width is 6 leaves, maximum is 5")
 
     val res = StarWarsMapping.compiler.compile(query)
     assert(res == Ior.Left(Chain(expected)))

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -185,12 +185,7 @@ final class VariablesSuite extends CatsSuite {
       }
     """
 
-    val expected =
-      json"""
-        {
-          "message" : "Unknown field(s) 'quux' in input object value of type Pattern"
-        }
-      """
+    val expected = Problem("Unknown field(s) 'quux' in input object value of type Pattern")
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)

--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -24,9 +24,9 @@ final class SchemaSpec extends CatsSuite {
     )
 
     schema match {
-      case Ior.Left(e) => assert(e.head.\\("message").head.asString.get == "Reference to undefined type: Episod")
+      case Ior.Left(e) => assert(e.head.message == "Reference to undefined type: Episod")
       case Both(a, b)  =>
-        assert(a.head.\\("message").head.asString.get == "Reference to undefined type: Episod")
+        assert(a.head.message == "Reference to undefined type: Episod")
         assert(b.types.map(_.name) == List("Query", "Episode"))
       case Ior.Right(b) => fail(s"Shouldn't compile: $b")
     }
@@ -49,7 +49,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.head.\\("message").head.asString.get == "Reference to undefined type: CCid")
+        assert(a.head.message == "Reference to undefined type: CCid")
         assert(b.types.map(_.name) == List("Query", "CCId", "Episode"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -73,7 +73,7 @@ final class SchemaSpec extends CatsSuite {
     )
 
     schema match {
-      case Ior.Left(e) => assert(e.head.\\("message").head.asString.get == "Duplicate NamedType found: Episode")
+      case Ior.Left(e) => assert(e.head.message == "Duplicate NamedType found: Episode")
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
@@ -88,7 +88,7 @@ final class SchemaSpec extends CatsSuite {
     )
 
     schema match {
-      case Ior.Left(e) => assert(e.head.\\("message").head.asString.get == "Only a single deprecated allowed at a given location")
+      case Ior.Left(e) => assert(e.head.message == "Only a single deprecated allowed at a given location")
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
@@ -104,7 +104,7 @@ final class SchemaSpec extends CatsSuite {
     )
 
     schema match {
-      case Ior.Left(e) => assert(e.head.\\("message").head.asString.get == "deprecated must have a single String 'reason' argument, or no arguments")
+      case Ior.Left(e) => assert(e.head.message == "deprecated must have a single String 'reason' argument, or no arguments")
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
@@ -121,7 +121,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.head.\\("message").head.asString.get == "Duplicate EnumValueDefinition of NORTH for EnumTypeDefinition Direction")
+        assert(a.head.message == "Duplicate EnumValueDefinition of NORTH for EnumTypeDefinition Direction")
         assert(b.types.map(_.name) == List("Direction"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -138,7 +138,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Interface Character implemented by Human is not defined", "Interface Contactable implemented by Human is not defined"))
+        assert(a.map(_.message) == NonEmptyChain("Interface Character implemented by Human is not defined", "Interface Contactable implemented by Human is not defined"))
         assert(b.types.map(_.name) == List("Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -161,7 +161,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by Human", "Expected field email from interface Character is not implemented by Human"))
+        assert(a.map(_.message) == NonEmptyChain("Expected field id from interface Character is not implemented by Human", "Expected field email from interface Character is not implemented by Human"))
         assert(b.types.map(_.name) == List("Character", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -184,7 +184,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by Named", "Expected field email from interface Character is not implemented by Named"))
+        assert(a.map(_.message) == NonEmptyChain("Expected field id from interface Character is not implemented by Named", "Expected field email from interface Character is not implemented by Named"))
         assert(b.types.map(_.name) == List("Character", "Named"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -205,7 +205,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Field name has type Int!, however implemented interface Character requires it to be of type String!"))
+        assert(a.map(_.message) == NonEmptyChain("Field name has type Int!, however implemented interface Character requires it to be of type String!"))
         assert(b.types.map(_.name) == List("Character", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -226,7 +226,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Field name of Human has has an argument list that does not match that specified by implemented interface Character"))
+        assert(a.map(_.message) == NonEmptyChain("Field name of Human has has an argument list that does not match that specified by implemented interface Character"))
         assert(b.types.map(_.name) == List("Character", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -252,7 +252,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by Human", "Expected field id from interface Character is not implemented by Dog"))
+        assert(a.map(_.message) == NonEmptyChain("Expected field id from interface Character is not implemented by Human", "Expected field id from interface Character is not implemented by Dog"))
         assert(b.types.map(_.name) == List("Character", "Human", "Dog"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
@@ -278,7 +278,7 @@ final class SchemaSpec extends CatsSuite {
 
     schema match {
       case Both(a, b)  =>
-        assert(a.map(_.\\("message").head.asString.get) == NonEmptyChain("Expected field id from interface Character is not implemented by Human", "Expected field email from interface Contactable is not implemented by Human"))
+        assert(a.map(_.message) == NonEmptyChain("Expected field id from interface Character is not implemented by Human", "Expected field email from interface Contactable is not implemented by Human"))
         assert(b.types.map(_.name) == List("Character", "Contactable", "Human"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -1175,7 +1175,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   override val interpreter: QueryInterpreter[F] =
     new QueryInterpreter(this) {
 
-      override def runRootValues(queries: List[(Query, Type, Env)]): Stream[F,(Chain[Json], List[ProtoJson])] =
+      override def runRootValues(queries: List[(Query, Type, Env)]): Stream[F,(Chain[Problem], List[ProtoJson])] =
         for {
           _   <- Stream.eval(monitor.stageStarted)
           res <- runRootValues0(queries)
@@ -1188,7 +1188,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           _   <- Stream.eval(monitor.resultComputed(res))
         } yield res
 
-      def runRootValues0(queries: List[(Query, Type, Env)]): Stream[F,(Chain[Json], List[ProtoJson])] = {
+      def runRootValues0(queries: List[(Query, Type, Env)]): Stream[F,(Chain[Problem], List[ProtoJson])] = {
         if (queries.length === 1)
           super.runRootValues(queries)
         else {


### PR DESCRIPTION
This changes `Result[+A]` to be `IorNec[Problem, A]` where `Problem` is a new data type containing message, locations, and path. `Problem` encodes to the same JSON structure we're generating now.

The use case for this is better error reporting for compile-time schema validation (#140).