### PR TITLE
Use type from `schemaTypes` in case of an array type for sql type name

### DIFF
--- a/modules/doobie/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie/src/main/scala/DoobieMapping.scala
@@ -7,11 +7,12 @@ package doobie
 import cats.Reducible
 import edu.gemini.grackle.sql._
 import cats.effect.Sync
-import _root_.doobie.{ Meta, Put, Fragment => DoobieFragment, Read, Transactor }
+import _root_.doobie.{ Meta, Put, Read, Transactor, Fragment => DoobieFragment }
 import _root_.doobie.enumerated.JdbcType._
-import _root_.doobie.enumerated.Nullability.{Nullable, NoNulls}
+import _root_.doobie.enumerated.Nullability.{ NoNulls, Nullable }
 import _root_.doobie.implicits._
 import _root_.doobie.util.fragments
+
 import java.sql.ResultSet
 import org.tpolecat.typename.TypeName
 
@@ -77,7 +78,6 @@ abstract class DoobieMapping[F[_]: Sync](
 
       def sqlTypeName(codec: Codec): Option[String] =
         codec._1.put.jdbcTargets.head match {
-          case Array                 => Some("ARRAY")
           case BigInt                => Some("BIGINT")
           case Binary                => Some("BINARY")
           case Bit                   => Some("BOOLEAN")
@@ -115,7 +115,7 @@ abstract class DoobieMapping[F[_]: Sync](
           case TinyInt               => Some("TINYINT")
           case VarBinary             => Some("VARBINARY")
           case VarChar               => Some("VARCHAR")
-          case Other                 =>
+          case Array | Other         =>
             codec._1.put match {
               case adv: Put.Advanced[_] =>
                 Some(adv.schemaTypes.head)

--- a/modules/doobie/src/test/scala/arrayjoin/ArrayJoinData.scala
+++ b/modules/doobie/src/test/scala/arrayjoin/ArrayJoinData.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package arrayjoin
+
+import cats.effect.Sync
+import doobie.Transactor
+import doobie.postgres.implicits._
+import doobie.util.meta.Meta
+import edu.gemini.grackle.doobie._
+import edu.gemini.grackle.syntax._
+
+import scala.reflect.ClassTag
+
+trait ArrayJoinData[F[_]] extends DoobieMapping[F] {
+
+  implicit def listMeta[T: ClassTag](implicit m: Meta[Array[T]]): Meta[List[T]] =
+    m.imap(_.toList)(_.toArray)
+
+  object root extends TableDef("array_join_root") {
+    val id = col("id", Meta[String])
+  }
+
+  object listA extends TableDef("array_join_list_a") {
+    val id = col("id", Meta[String])
+    val rootId = col("root_id", Meta[String], true)
+    val aElem = col("a_elem", Meta[List[String]], true)
+  }
+
+  object listB extends TableDef("array_join_list_b") {
+    val id = col("id", Meta[String])
+    val rootId = col("root_id", Meta[String], true)
+    val bElem = col("b_elem", Meta[Int], true)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        root: [Root!]!
+      }
+      type Root {
+        id: String!
+        listA: [ElemA!]!
+        listB: [ElemB!]!
+      }
+      type ElemA {
+        id: String!
+        elemA: [String!]
+      }
+      type ElemB {
+        id: String!
+        elemB: Int
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val RootType = schema.ref("Root")
+  val ElemAType = schema.ref("ElemA")
+  val ElemBType = schema.ref("ElemB")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlRoot("root")
+          )
+      ),
+      ObjectMapping(
+        tpe = RootType,
+        fieldMappings =
+          List(
+            SqlField("id", root.id, key = true),
+            SqlObject("listA", Join(root.id, listA.rootId)),
+            SqlObject("listB", Join(root.id, listB.rootId))
+          )
+      ),
+      ObjectMapping(
+        tpe = ElemAType,
+        fieldMappings =
+          List(
+            SqlField("id", listA.id, key = true),
+            SqlField("rootId", listA.rootId, hidden = true),
+            SqlField("elemA", listA.aElem)
+          )
+      ),
+      ObjectMapping(
+        tpe = ElemBType,
+        fieldMappings =
+          List(
+            SqlField("id", listB.id, key = true),
+            SqlField("rootId", listB.rootId, hidden = true),
+            SqlField("elemB", listB.bElem)
+          )
+      )
+    )
+}
+
+object ArrayJoinData extends DoobieMappingCompanion {
+  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): ArrayJoinData[F] =
+    new DoobieMapping(transactor, monitor) with ArrayJoinData[F]
+}

--- a/modules/doobie/src/test/scala/arrayjoin/ArrayJoinSpec.scala
+++ b/modules/doobie/src/test/scala/arrayjoin/ArrayJoinSpec.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package arrayjoin
+
+import grackle.test.SqlArrayJoinSpec
+import utils.DatabaseSuite
+
+final class ArrayJoinSpec extends DatabaseSuite with SqlArrayJoinSpec {
+  lazy val mapping = ArrayJoinData.fromTransactor(xa)
+}

--- a/modules/sql/src/test/resources/db/array-join.sql
+++ b/modules/sql/src/test/resources/db/array-join.sql
@@ -1,0 +1,42 @@
+CREATE TABLE array_join_root (
+  id VARCHAR PRIMARY KEY
+);
+
+CREATE TABLE array_join_list_a (
+  id VARCHAR PRIMARY KEY,
+  root_id VARCHAR,
+  a_elem VARCHAR[]
+);
+
+CREATE TABLE array_join_list_b (
+  id VARCHAR PRIMARY KEY,
+  root_id VARCHAR,
+  b_elem INTEGER
+);
+
+COPY array_join_root (id) FROM STDIN WITH DELIMITER '|';
+r0
+r1
+\.
+
+COPY array_join_list_a (id, root_id, a_elem) FROM STDIN WITH DELIMITER '|';
+a0|r0|{foo1,foo2}
+a1|r0|{bar1,bar2}
+a2|r0|{baz1,baz2}
+a3|r0|{quux1,quux2}
+a4|r1|{foo11,foo22}
+a5|r1|{bar11,bar22}
+a6|r1|{baz11,baz22}
+a7|r1|{quux11,quux22}
+\.
+
+COPY array_join_list_b (id, root_id, b_elem) FROM STDIN WITH DELIMITER '|';
+b0|r0|23
+b1|r0|13
+b2|r0|17
+b3|r0|11
+b4|r1|231
+b5|r1|131
+b6|r1|171
+b7|r1|111
+\.

--- a/modules/sql/src/test/scala/SqlArrayJoinSpec.scala
+++ b/modules/sql/src/test/scala/SqlArrayJoinSpec.scala
@@ -1,0 +1,123 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package grackle.test
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+
+trait SqlArrayJoinSpec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("base query") {
+    val query = """
+      query {
+        root {
+          listA {
+            id
+            elemA
+          }
+          listB {
+            id
+            elemB
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "root" : [
+            {
+              "listA" : [
+                {
+                  "id" : "a0",
+                  "elemA" : ["foo1","foo2"]
+                },
+                {
+                  "id" : "a1",
+                  "elemA" : ["bar1","bar2"]
+                },
+                {
+                  "id" : "a2",
+                  "elemA" : ["baz1","baz2"]
+                },
+                {
+                  "id" : "a3",
+                  "elemA" : ["quux1","quux2"]
+                }
+              ],
+              "listB" : [
+                {
+                  "id" : "b0",
+                  "elemB" : 23
+                },
+                {
+                  "id" : "b1",
+                  "elemB" : 13
+                },
+                {
+                  "id" : "b2",
+                  "elemB" : 17
+                },
+                {
+                  "id" : "b3",
+                  "elemB" : 11
+                }
+              ]
+            },
+            {
+              "listA" : [
+                {
+                  "id" : "a4",
+                  "elemA" : ["foo11","foo22"]
+                },
+                {
+                  "id" : "a5",
+                  "elemA" : ["bar11","bar22"]
+                },
+                {
+                  "id" : "a6",
+                  "elemA" : ["baz11","baz22"]
+                },
+                {
+                  "id" : "a7",
+                  "elemA" : ["quux11","quux22"]
+                }
+              ],
+              "listB" : [
+                {
+                  "id" : "b4",
+                  "elemB" : 231
+                },
+                {
+                  "id" : "b5",
+                  "elemB" : 131
+                },
+                {
+                  "id" : "b6",
+                  "elemB" : 171
+                },
+                {
+                  "id" : "b7",
+                  "elemB" : 111
+                }
+              ]
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
Fixes #164