### PR TITLE
expose compileUntyped

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -307,13 +307,15 @@ class QueryCompiler(schema: Schema, phases: List[Phase]) {
    *
    * Any errors are accumulated on the left.
    */
-  def compile(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full): Result[Operation] = {
+  def compile(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full): Result[Operation] =
+    QueryParser.parseText(text, name).flatMap(compileUntyped(_, untypedVars, introspectionLevel))
+
+  def compileUntyped(parsed: UntypedOperation, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full): Result[Operation] = {
 
     val allPhases =
       IntrospectionElaborator(introspectionLevel).toList ++ (VariablesAndSkipElaborator :: phases)
 
     for {
-      parsed  <- QueryParser.parseText(text, name)
       varDefs <- compileVarDefs(parsed.variables)
       vars    <- compileVars(varDefs, untypedVars)
       rootTpe <- parsed.rootTpe(schema)


### PR DESCRIPTION
I'm writing a routing layer that needs to know whether a query is a subscription or not. In order to do this I can call `QueryParser.parseText` and look at the resulting `UntypedOperation`, but there's no public way to compile this intermediate result down to an `Operation`. This PR just exposes that operation.