### PR TITLE
Big decimal not taken as a scalar

### DIFF
--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -71,6 +71,7 @@ abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
         case e: EnumType       if focus.isString  =>
           if (focus.asString.map(e.hasValue).getOrElse(false)) focus.rightIor
           else mkErrorResult(s"Expected Enum ${e.name}, found ${focus.noSpaces}")
+        case _: ScalarType     if !focus.isObject => focus.rightIor // custom Scalar; any non-object type is fine
         case _ =>
           mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus.noSpaces}")
       }

--- a/modules/circe/src/test/scala/CirceData.scala
+++ b/modules/circe/src/test/scala/CirceData.scala
@@ -30,6 +30,7 @@ object TestCirceMapping extends CirceMapping[Id] {
         array: [Int!]
         object: A
         numChildren: Int
+        bigDecimal: BigDecimal
         children: [Child!]!
       }
       enum Choice {
@@ -48,10 +49,12 @@ object TestCirceMapping extends CirceMapping[Id] {
         id: ID
         bField: String
       }
+      scalar BigDecimal
     """
 
   val QueryType = schema.ref("Query")
   val RootType = schema.ref("Root")
+  val BigDecimalType = schema.ref("BigDecimal")
 
   val data =
     json"""
@@ -60,6 +63,7 @@ object TestCirceMapping extends CirceMapping[Id] {
         "int": 23,
         "float": 1.3,
         "string": "foo",
+        "bigDecimal": 1.2,
         "id": "bar",
         "array": [1, 2, 3],
         "choice": "ONE",
@@ -88,7 +92,8 @@ object TestCirceMapping extends CirceMapping[Id] {
           List(
             CirceRoot("root", data),
           )
-      )
+      ),
+      LeafMapping[BigDecimal](BigDecimalType)
     )
 
   override val selectElaborator = new SelectElaborator(Map(

--- a/modules/circe/src/test/scala/CirceSpec.scala
+++ b/modules/circe/src/test/scala/CirceSpec.scala
@@ -16,6 +16,7 @@ final class CirceSpec extends CatsSuite {
           int
           float
           string
+          bigDecimal
           id
         }
       }
@@ -29,6 +30,7 @@ final class CirceSpec extends CatsSuite {
             "int" : 23,
             "float": 1.3,
             "string": "foo",
+            "bigDecimal": 1.2,
             "id": "bar"
           }
         }


### PR DESCRIPTION
This is not a code change but just a demonstration of an issue discussed in discord about scalar types

I think I tracked it to this line
https://github.com/gemini-hlsw/gsp-graphql/blob/main/modules/core/src/main/scala/schema.scala#L933

There I can see that `ScalarTypes` can only be the types defined in :
https://github.com/gemini-hlsw/gsp-graphql/blob/main/modules/core/src/main/scala/schema.scala#L459