### PR TITLE
Improved parser errors

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -37,10 +37,9 @@ object QueryParser {
                 s"""Parse error at line $row column $col
                    |$line
                    |${List.fill(col)(" ").mkString}^""".stripMargin
-              case None => "Uh-oh! There seems to be a bug in Cats Parse :("
+              case None => "Malformed query" //This is probably a bug in Cats Parse as it has given us the (row, col) index
             }
-          case None =>
-            "Parse error at EOF"
+          case None => "Truncated query"
         }
         mkOneError(error)
       }

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -360,7 +360,12 @@ final class CompilerSuite extends CatsSuite {
 
     val res = QueryParser.parseText(query)
 
-    assert(res == Ior.Left(mkOneError("Malformed query")))
+    val error =
+      """Parse error at line 2 column 29
+        |        character(id: "1000" {
+        |                             ^""".stripMargin
+
+    assert(res == Ior.Left(mkOneError(error)))
   }
 
   test("malformed query (2)") {
@@ -381,7 +386,12 @@ final class CompilerSuite extends CatsSuite {
 
     val res = QueryParser.parseText(query)
 
-    assert(res == Ior.Left(mkOneError("Malformed query")))
+    val error =
+      """Parse error at line 2 column 29
+        |        character(id: "1000" {
+        |                             ^""".stripMargin
+
+    assert(res == Ior.Left(mkOneError(error)))
   }
 }
 

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -386,8 +386,7 @@ final class CompilerSuite extends CatsSuite {
 
     val res = QueryParser.parseText(query)
 
-    val error =
-      "Parse error at EOF"
+    val error = "Truncated query"
 
     assert(res == Ior.Left(mkOneError(error)))
   }

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -379,7 +379,7 @@ final class CompilerSuite extends CatsSuite {
   test("malformed query (3)") {
     val query = """
       query {
-        character(id: "1000" {
+        character(id: "1000") {
           name
         }
     """
@@ -387,9 +387,7 @@ final class CompilerSuite extends CatsSuite {
     val res = QueryParser.parseText(query)
 
     val error =
-      """Parse error at line 2 column 29
-        |        character(id: "1000" {
-        |                             ^""".stripMargin
+      "Parse error at EOF"
 
     assert(res == Ior.Left(mkOneError(error)))
   }


### PR DESCRIPTION
Example query:
```
query {
  character(id: "1000" {
    name
}
```

Parser error:
```
Parse error at line 2 column 29
        character(id: "1000" {
                             ^
```