### PR TITLE
Fix directive location parsing

### DIFF
--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -128,6 +128,7 @@ object GraphQLParser {
     keyword("QUERY")       .as(Ast.DirectiveLocation.QUERY) |
     keyword("MUTATION")    .as(Ast.DirectiveLocation.MUTATION) |
     keyword("SUBSCRIPTION").as(Ast.DirectiveLocation.SUBSCRIPTION) |
+    keyword("FIELD_DEFINITION").as(Ast.DirectiveLocation.FIELD_DEFINITION) |
     keyword("FIELD").as(Ast.DirectiveLocation.FIELD) |
     keyword("FRAGMENT_DEFINITION").as(Ast.DirectiveLocation.FRAGMENT_DEFINITION) |
     keyword("FRAGMENT_SPREAD").as(Ast.DirectiveLocation.FRAGMENT_SPREAD) |
@@ -136,12 +137,11 @@ object GraphQLParser {
     keyword("SCHEMA").as(Ast.DirectiveLocation.SCHEMA) |
     keyword("SCALAR").as(Ast.DirectiveLocation.SCALAR) |
     keyword("OBJECT").as(Ast.DirectiveLocation.OBJECT) |
-    keyword("FIELD_DEFINITION").as(Ast.DirectiveLocation.FIELD_DEFINITION) |
     keyword("ARGUMENT_DEFINITION").as(Ast.DirectiveLocation.ARGUMENT_DEFINITION) |
     keyword("INTERFACE").as(Ast.DirectiveLocation.INTERFACE) |
     keyword("UNION").as(Ast.DirectiveLocation.UNION) |
-    keyword("ENUM").as(Ast.DirectiveLocation.ENUM) |
     keyword("ENUM_VALUE").as(Ast.DirectiveLocation.ENUM_VALUE) |
+    keyword("ENUM").as(Ast.DirectiveLocation.ENUM) |
     keyword("INPUT_OBJECT").as(Ast.DirectiveLocation.INPUT_OBJECT) |
     keyword("INPUT_FIELD_DEFINITION").as(Ast.DirectiveLocation.INPUT_FIELD_DEFINITION)
 

--- a/modules/core/src/test/scala/sdl/SDLSpec.scala
+++ b/modules/core/src/test/scala/sdl/SDLSpec.scala
@@ -196,7 +196,7 @@ final class SDLSuite extends CatsSuite {
   test("parse directive definition") {
     val schema = """
       "A directive"
-      directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
+      directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE | FIELD | FIELD_DEFINITION | ENUM | ENUM_VALUE
     """
 
     val expected =
@@ -208,7 +208,14 @@ final class SDLSuite extends CatsSuite {
             InputValueDefinition(Name("name"), None, NonNull(Left(Named(Name("String")))), None, Nil)
           ),
           true,
-          List(DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE)
+          List(
+            DirectiveLocation.OBJECT,
+            DirectiveLocation.INTERFACE,
+            DirectiveLocation.FIELD,
+            DirectiveLocation.FIELD_DEFINITION,
+            DirectiveLocation.ENUM,
+            DirectiveLocation.ENUM_VALUE
+          )
         )
       )
 


### PR DESCRIPTION
Make sure that parsers for locations in directive definitions will correctly allow for backtracking. This does not happen if a directive location happens to be a prefix of another one **and** if the corresponding parser is attempted before that other one.