### PR TITLE
Fix `sbt docs/previewSite` on Java 17

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,1 @@
+-J--add-opens=java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
`sbt docs/previewSite` on Java 17 currently fails with

```
[error] java.lang.RuntimeException: Error creating extended parser class: Could not determine whether class 'org.pegdown.ParserWithDirectives$$parboiled' has already been loaded
```

The underlying issue and fix are discussed in https://github.com/sirthias/parboiled/issues/175