### PR TITLE
add parens around binops

### DIFF
--- a/modules/doobie/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie/src/test/scala/DoobieSuites.scala
@@ -49,7 +49,7 @@ final class GraphSpec extends DoobieDatabaseSuite with SqlGraphSpec {
 }
 
 final class InterfacesSpec extends DoobieDatabaseSuite with SqlInterfacesSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new DoobieTestMapping(xa) with SqlInterfacesMapping[IO] {
       def entityType: Codec =
         (Meta[Int].timap(EntityType.fromInt)(EntityType.toInt), false)
@@ -61,7 +61,7 @@ final class JsonbSpec extends DoobieDatabaseSuite with SqlJsonbSpec {
 }
 
 final class MovieSpec extends DoobieDatabaseSuite with SqlMovieSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new DoobieTestMapping(xa) with SqlMovieMapping[IO] {
       def genre: Codec = (Meta[Int].imap(Genre.fromInt)(Genre.toInt), false)
       def feature: Codec = (Meta[String].imap(Feature.fromString)(_.toString), false)
@@ -69,7 +69,7 @@ final class MovieSpec extends DoobieDatabaseSuite with SqlMovieSpec {
 }
 
 final class MutationSpec extends DoobieDatabaseSuite with SqlMutationSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new DoobieTestMapping(xa) with SqlMutationMapping[IO] {
       def updatePopulation(id: Int, population: Int): IO[Unit] =
         sql"update city set population=$population where id=$id"
@@ -94,7 +94,7 @@ final class ProjectionSpec extends DoobieDatabaseSuite with SqlProjectionSpec {
 }
 
 final class RecursiveInterfacesSpec extends DoobieDatabaseSuite with SqlRecursiveInterfacesSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new DoobieTestMapping(xa) with SqlRecursiveInterfacesMapping[IO] {
       def itemType: Codec =
         (Meta[Int].timap(ItemType.fromInt)(ItemType.toInt), false)
@@ -124,7 +124,7 @@ final class WorldCompilerSpec extends DoobieDatabaseSuite with SqlWorldCompilerS
     DoobieMonitor.statsMonitor[IO].map(mon => (new DoobieTestMapping(xa, mon) with SqlWorldMapping[IO], mon))
 
   def simpleRestrictedQuerySql: String =
-    "SELECT country.code , country.name FROM country WHERE (country.code = ?)"
+    "SELECT country.code , country.name FROM country WHERE (( country.code = ?) )"
 
   def simpleFilteredQuerySql: String =
     "SELECT city.id , city.name FROM city WHERE (city.name ILIKE ?)"

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -49,7 +49,7 @@ final class GraphSpec extends SkunkDatabaseSuite with SqlGraphSpec {
 }
 
 final class InterfacesSpec extends SkunkDatabaseSuite with SqlInterfacesSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new SkunkTestMapping(pool) with SqlInterfacesMapping[IO] {
       def entityType: Codec =
         (codec.int4.imap(EntityType.fromInt)(EntityType.toInt), false)
@@ -61,7 +61,7 @@ final class JsonbSpec extends SkunkDatabaseSuite with SqlJsonbSpec {
 }
 
 final class MovieSpec extends SkunkDatabaseSuite with SqlMovieSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new SkunkTestMapping(pool) with SqlMovieMapping[IO] {
       def genre: Codec = (codec.int4.imap(Genre.fromInt)(Genre.toInt), false)
       def feature: Codec = (codec.varchar.imap(Feature.fromString)(_.toString), false)
@@ -69,7 +69,7 @@ final class MovieSpec extends SkunkDatabaseSuite with SqlMovieSpec {
 }
 
 final class MutationSpec extends SkunkDatabaseSuite with SqlMutationSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new SkunkTestMapping(pool) with SqlMutationMapping[IO] {
       def updatePopulation(id: Int, population: Int): IO[Unit] =
         pool.use { s =>
@@ -97,7 +97,7 @@ final class ProjectionSpec extends SkunkDatabaseSuite with SqlProjectionSpec {
 }
 
 final class RecursiveInterfacesSpec extends SkunkDatabaseSuite with SqlRecursiveInterfacesSpec {
-  lazy val mapping = 
+  lazy val mapping =
     new SkunkTestMapping(pool) with SqlRecursiveInterfacesMapping[IO] {
       def itemType: Codec =
         (codec.int4.imap(ItemType.fromInt)(ItemType.toInt), false)
@@ -127,7 +127,7 @@ final class WorldCompilerSpec extends SkunkDatabaseSuite with SqlWorldCompilerSp
     SkunkMonitor.statsMonitor[IO].map(mon => (new SkunkTestMapping(pool, mon) with SqlWorldMapping[IO], mon))
 
   def simpleRestrictedQuerySql: String =
-    "SELECT country.code, country.name FROM country WHERE (country.code = $1)"
+    "SELECT country.code, country.name FROM country WHERE ((country.code = $1))"
 
   def simpleFilteredQuerySql: String =
     "SELECT city.id, city.name FROM city WHERE (city.name ILIKE $1)"

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -1281,7 +1281,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           for {
             fx <- loop(x, e)
             fy <- loop(y, e)
-          } yield fx |+| op |+| fy
+          } yield Fragments.const("(") |+| fx |+| op |+| fy |+| Fragments.const(")")
         }
 
         def binaryOp2(x: Term[_])(op: Fragment => Fragment, enc: Option[Encoder] = None): Aliased[Fragment] = {


### PR DESCRIPTION
Filter expression `And(x, OR(y, z))` compiles to SQL expression `x AND y OR z` which means `(x AND y) OR z`, which is incorrect. This fixes it by adding parens around every binop.

We could try to get rid of extra parens when possible but this seems very low-priority to me.