### PR TITLE
internalize unique/list distinction for paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val Scala3 = "3.1.3"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.6"
+ThisBuild / tlBaseVersion    := "0.7"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
+++ b/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
@@ -5,7 +5,6 @@ package demo.starwars
 
 import cats._
 import cats.implicits._
-import edu.gemini.grackle.Path._
 import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query._
 import edu.gemini.grackle.QueryCompiler._
@@ -212,14 +211,14 @@ object StarWarsMapping extends GenericMapping[Id] {
       // Unique operator to pick out the target using the FieldEquals predicate.
       case Select("hero", List(Binding("episode", TypedEnumValue(e))), child) =>
         Episode.values.find(_.toString == e.name).map { episode =>
-          Select("hero", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(hero(episode).id)), child))).rightIor
+          Select("hero", Nil, Unique(Filter(Eql(CharacterType / "id", Const(hero(episode).id)), child))).rightIor
         }.getOrElse(mkErrorResult(s"Unknown episode '${e.name}'"))
 
       // The character, human and droid selectors all take a single ID argument and yield a
       // single value (if any) or null. We use the Unique operator to pick out the target
       // using the FieldEquals predicate.
       case Select(f@("character" | "human" | "droid"), List(Binding("id", IDValue(id))), child) =>
-        Select(f, Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select(f, Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).rightIor
     }
   ))
   // #elaborator

--- a/demo/src/main/scala/demo/world/WorldMapping.scala
+++ b/demo/src/main/scala/demo/world/WorldMapping.scala
@@ -6,7 +6,6 @@ package demo.world
 import _root_.doobie.{Meta, Transactor}
 import cats.effect.Sync
 import cats.implicits._
-import edu.gemini.grackle.Path._
 import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query._
 import edu.gemini.grackle.QueryCompiler._
@@ -175,10 +174,10 @@ trait WorldMapping[F[_]] extends DoobieMapping[F] {
     QueryType -> {
 
       case Select("country", List(Binding("code", StringValue(code))), child) =>
-        Select("country", Nil, Unique(Filter(Eql(UniquePath(List("code")), Const(code)), child))).rightIor
+        Select("country", Nil, Unique(Filter(Eql(CountryType / "code", Const(code)), child))).rightIor
 
       case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).rightIor
 
       case Select("countries", List(Binding("limit", IntValue(num)), Binding("offset", IntValue(off)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop))), child) =>
         def limit(query: Query): Query =
@@ -191,15 +190,15 @@ trait WorldMapping[F[_]] extends DoobieMapping[F] {
 
         def order(query: Query): Query = {
           if (byPop)
-            OrderBy(OrderSelections(List(OrderSelection(UniquePath[Int](List("population"))))), query)
+            OrderBy(OrderSelections(List(OrderSelection[Int](CountryType / "population"))), query)
           else if (num > 0 || off > 0)
-            OrderBy(OrderSelections(List(OrderSelection(UniquePath[String](List("code"))))), query)
+            OrderBy(OrderSelections(List(OrderSelection[String](CountryType / "code"))), query)
           else query
         }
 
         def filter(query: Query): Query =
           if (min == 0) query
-          else Filter(GtEql(UniquePath(List("population")), Const(min)), query)
+          else Filter(GtEql(CountryType / "population", Const(min)), query)
 
         Select("countries", Nil, limit(offset(order(filter(child))))).rightIor
 
@@ -207,31 +206,31 @@ trait WorldMapping[F[_]] extends DoobieMapping[F] {
         if (namePattern == "%")
           Select("cities", Nil, child).rightIor
         else
-          Select("cities", Nil, Filter(Like(UniquePath(List("name")), namePattern, true), child)).rightIor
+          Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), child)).rightIor
 
       case Select("language", List(Binding("language", StringValue(language))), child) =>
-        Select("language", Nil, Unique(Filter(Eql(UniquePath(List("language")), Const(language)), child))).rightIor
+        Select("language", Nil, Unique(Filter(Eql(LanguageType / "language", Const(language)), child))).rightIor
 
       case Select("search", List(Binding("minPopulation", IntValue(min)), Binding("indepSince", IntValue(year))), child) =>
         Select("search", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("population")), Const(min))),
-              Not(Lt(UniquePath(List("indepyear")), Const(Option(year))))
+              Not(Lt(CountryType / "population", Const(min))),
+              Not(Lt(CountryType / "indepyear", Const(Option(year))))
             ),
             child
           )
         ).rightIor
 
       case Select("search2", List(Binding("indep", BooleanValue(indep)), Binding("limit", IntValue(num))), child) =>
-        Select("search2", Nil, Limit(num, Filter(IsNull[Int](UniquePath(List("indepyear")), isNull = !indep), child))).rightIor
+        Select("search2", Nil, Limit(num, Filter(IsNull[Int](CountryType / "indepyear", isNull = !indep), child))).rightIor
     },
     CountryType -> {
       case Select("numCities", List(Binding("namePattern", AbsentValue)), Empty) =>
         Count("numCities", Select("cities", Nil, Select("name", Nil, Empty))).rightIor
 
       case Select("numCities", List(Binding("namePattern", StringValue(namePattern))), Empty) =>
-        Count("numCities", Select("cities", Nil, Filter(Like(UniquePath(List("name")), namePattern, true), Select("name", Nil, Empty)))).rightIor
+        Count("numCities", Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), Select("name", Nil, Empty)))).rightIor
     }
   ))
   // #elaborator

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -10,7 +10,7 @@ import cats.parse.{LocationMap, Parser}
 import cats.implicits._
 import io.circe.Json
 
-import Query._, Predicate._, Path._, Value._, UntypedOperation._
+import Query._, /*Predicate._, Path._, */Value._, UntypedOperation._
 import QueryCompiler._
 import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ScalarType._
@@ -614,16 +614,16 @@ object QueryCompiler {
   }
 
   val introspectionMapping: Map[TypeRef, PartialFunction[Select, Result[Query]]] = Map(
-    Introspection.schema.ref("Query") -> {
-      case sel@Select("__type", List(Binding("name", StringValue(name))), _) =>
-        sel.eliminateArgs(child => Unique(Filter(Eql(UniquePath(List("name")), Const(Option(name))), child))).rightIor
-    },
-    Introspection.schema.ref("__Type") -> {
-      case sel@Select("fields", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
-        sel.eliminateArgs(child => if (include) child else Filter(Eql(UniquePath(List("isDeprecated")), Const(false)), child)).rightIor
-      case sel@Select("enumValues", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
-        sel.eliminateArgs(child => if (include) child else Filter(Eql(UniquePath(List("isDeprecated")), Const(false)), child)).rightIor
-    }
+    // Introspection.schema.ref("Query") -> {
+    //   case sel@Select("__type", List(Binding("name", StringValue(name))), _) =>
+    //     sel.eliminateArgs(child => Unique(Filter(Eql(UniquePath(List("name")), Const(Option(name))), child))).rightIor
+    // },
+    // Introspection.schema.ref("__Type") -> {
+    //   case sel@Select("fields", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
+    //     sel.eliminateArgs(child => if (include) child else Filter(Eql(UniquePath(List("isDeprecated")), Const(false)), child)).rightIor
+    //   case sel@Select("enumValues", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
+    //     sel.eliminateArgs(child => if (include) child else Filter(Eql(UniquePath(List("isDeprecated")), Const(false)), child)).rightIor
+    // }
   )
 
   /**

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -10,7 +10,7 @@ import cats.parse.{LocationMap, Parser}
 import cats.implicits._
 import io.circe.Json
 
-import Query._, /*Predicate._, Path._, */Value._, UntypedOperation._
+import Query._, Predicate._, Value._, UntypedOperation._
 import QueryCompiler._
 import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ScalarType._
@@ -613,18 +613,23 @@ object QueryCompiler {
       }
   }
 
-  val introspectionMapping: Map[TypeRef, PartialFunction[Select, Result[Query]]] = Map(
-    // Introspection.schema.ref("Query") -> {
-    //   case sel@Select("__type", List(Binding("name", StringValue(name))), _) =>
-    //     sel.eliminateArgs(child => Unique(Filter(Eql(UniquePath(List("name")), Const(Option(name))), child))).rightIor
-    // },
-    // Introspection.schema.ref("__Type") -> {
-    //   case sel@Select("fields", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
-    //     sel.eliminateArgs(child => if (include) child else Filter(Eql(UniquePath(List("isDeprecated")), Const(false)), child)).rightIor
-    //   case sel@Select("enumValues", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
-    //     sel.eliminateArgs(child => if (include) child else Filter(Eql(UniquePath(List("isDeprecated")), Const(false)), child)).rightIor
-    // }
-  )
+  val introspectionMapping: Map[TypeRef, PartialFunction[Select, Result[Query]]] = {
+    val TypeType = Introspection.schema.ref("__Type")
+    val FieldType = Introspection.schema.ref("__Field")
+    val EnumValueType = Introspection.schema.ref("__EnumValue")
+    Map(
+      Introspection.schema.ref("Query") -> {
+        case sel@Select("__type", List(Binding("name", StringValue(name))), _) =>
+          sel.eliminateArgs(child => Unique(Filter(Eql(TypeType / "name", Const(Option(name))), child))).rightIor
+      },
+      Introspection.schema.ref("__Type") -> {
+        case sel@Select("fields", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
+          sel.eliminateArgs(child => if (include) child else Filter(Eql(FieldType / "isDeprecated", Const(false)), child)).rightIor
+        case sel@Select("enumValues", List(Binding("includeDeprecated", BooleanValue(include))), _) =>
+          sel.eliminateArgs(child => if (include) child else Filter(Eql(EnumValueType / "isDeprecated", Const(false)), child)).rightIor
+      }
+    )
+  }
 
   /**
    * A compiler phase which partitions a query for execution by multiple

--- a/modules/core/src/main/scala/predicate.scala
+++ b/modules/core/src/main/scala/predicate.scala
@@ -45,6 +45,7 @@ trait TermLow {
     p.asTerm[List[A]]
 }
 
+/** A path starting from some root type. */
 case class Path private (root: Type, path: List[String]) {
 
   def asTerm[A]: Term[A] =
@@ -64,6 +65,7 @@ case class Path private (root: Type, path: List[String]) {
 
 object Path {
 
+  /** Construct an empty `Path` rooted at the given type. */
   def from(tpe: Type): Path =
     Path(tpe, Nil)
 
@@ -92,57 +94,6 @@ object PathTerm {
   }
 
 }
-
-
-// sealed trait Path {
-//   def path: List[String]
-//   def prepend(prefix: List[String]): Path
-// }
-
-// object Path {
-//   import Predicate.ScalarFocus
-
-//   /**
-//     * Reifies a traversal from a Cursor to a single, possibly nullable, value.
-//     *
-//     * Typically such a path would use used to identify a field of the object
-//     * or interface at the focus of the cursor, to be tested via a predicate
-//     * such as `Eql`.
-//     */
-//   case class UniquePath[T](val path: List[String]) extends Term[T] with Path {
-//     def apply(c: Cursor): Result[T] =
-//       c.listPath(path) match {
-//         case Ior.Right(List(ScalarFocus(a: T @unchecked))) => a.rightIor
-//         case other => mkErrorResult(s"Expected exactly one element for path $path found $other")
-//       }
-
-//     def prepend(prefix: List[String]): Path =
-//       UniquePath(prefix ++ path)
-
-//     def children = Nil
-//   }
-
-//   /**
-//     * Reifies a traversal from a Cursor to multiple, possibly nullable, values.
-//     *
-//     * Typically such a path would use used to identify the list of values of
-//     * an attribute of the object elements of a list field of the object or
-//     * interface at the focus of the cursor, to be tested via a predicate such
-//     * as `In`.
-//     */
-//   case class ListPath[T](val path: List[String]) extends Term[List[T]] with Path {
-//     def apply(c: Cursor): Result[List[T]] =
-//       c.flatListPath(path).map(_.map {
-//         case ScalarFocus(f: T @unchecked) => f
-//         case _ => sys.error("impossible")
-//       })
-
-//     def prepend(prefix: List[String]): Path =
-//       ListPath(prefix ++ path)
-
-//     def children = Nil
-//   }
-// }
 
 trait Predicate extends Term[Boolean]
 

--- a/modules/core/src/main/scala/predicate.scala
+++ b/modules/core/src/main/scala/predicate.scala
@@ -35,55 +35,114 @@ trait Term[T] extends Product with Serializable { // fun fact: making this covar
     f(this) && children.forall(_.forall(f))
 }
 
-sealed trait Path {
-  def path: List[String]
-  def prepend(prefix: List[String]): Path
+object Term extends TermLow {
+  implicit def path2Term[A](p: Path): Term[A] =
+    p.asTerm[A]
+}
+
+trait TermLow {
+  implicit def path2ListTerm[A](p: Path): Term[List[A]] =
+    p.asTerm[List[A]]
+}
+
+case class Path private (root: Type, path: List[String]) {
+
+  def asTerm[A]: Term[A] =
+    if (isList) PathTerm.ListPath(path)
+    else PathTerm.UniquePath(path)
+
+  lazy val isList: Boolean = root.pathIsList(path)
+  lazy val tpe: Option[Type] = root.path(path)
+
+  def prepend(prefix: List[String]): Path =
+    copy(path = prefix ++ path)
+
+  def /(elem: String): Path =
+    copy(path = path :+ elem)
+
 }
 
 object Path {
-  import Predicate.ScalarFocus
 
-  /**
-    * Reifies a traversal from a Cursor to a single, possibly nullable, value.
-    *
-    * Typically such a path would use used to identify a field of the object
-    * or interface at the focus of the cursor, to be tested via a predicate
-    * such as `Eql`.
-    */
-  case class UniquePath[T](val path: List[String]) extends Term[T] with Path {
-    def apply(c: Cursor): Result[T] =
+  def from(tpe: Type): Path =
+    Path(tpe, Nil)
+
+}
+
+sealed trait PathTerm[A] extends Term[A] {
+  def children: List[Term[_]] =  Nil
+  def path: List[String]
+}
+object PathTerm {
+
+  case class ListPath[A](path: List[String]) extends PathTerm[A] {
+    def apply(c: Cursor): Result[A] =
+      c.flatListPath(path).map(_.map {
+        case Predicate.ScalarFocus(f) => f
+        case _ => sys.error("impossible")
+      } .asInstanceOf[A])
+  }
+
+  case class UniquePath[A](path: List[String]) extends PathTerm[A] {
+    def apply(c: Cursor): Result[A] =
       c.listPath(path) match {
-        case Ior.Right(List(ScalarFocus(a: T @unchecked))) => a.rightIor
+        case Ior.Right(List(Predicate.ScalarFocus(a: A @unchecked))) => a.rightIor
         case other => mkErrorResult(s"Expected exactly one element for path $path found $other")
       }
-
-    def prepend(prefix: List[String]): Path =
-      UniquePath(prefix ++ path)
-
-    def children = Nil
   }
 
-  /**
-    * Reifies a traversal from a Cursor to multiple, possibly nullable, values.
-    *
-    * Typically such a path would use used to identify the list of values of
-    * an attribute of the object elements of a list field of the object or
-    * interface at the focus of the cursor, to be tested via a predicate such
-    * as `In`.
-    */
-  case class ListPath[T](val path: List[String]) extends Term[List[T]] with Path {
-    def apply(c: Cursor): Result[List[T]] =
-      c.flatListPath(path).map(_.map {
-        case ScalarFocus(f: T @unchecked) => f
-        case _ => sys.error("impossible")
-      })
-
-    def prepend(prefix: List[String]): Path =
-      ListPath(prefix ++ path)
-
-    def children = Nil
-  }
 }
+
+
+// sealed trait Path {
+//   def path: List[String]
+//   def prepend(prefix: List[String]): Path
+// }
+
+// object Path {
+//   import Predicate.ScalarFocus
+
+//   /**
+//     * Reifies a traversal from a Cursor to a single, possibly nullable, value.
+//     *
+//     * Typically such a path would use used to identify a field of the object
+//     * or interface at the focus of the cursor, to be tested via a predicate
+//     * such as `Eql`.
+//     */
+//   case class UniquePath[T](val path: List[String]) extends Term[T] with Path {
+//     def apply(c: Cursor): Result[T] =
+//       c.listPath(path) match {
+//         case Ior.Right(List(ScalarFocus(a: T @unchecked))) => a.rightIor
+//         case other => mkErrorResult(s"Expected exactly one element for path $path found $other")
+//       }
+
+//     def prepend(prefix: List[String]): Path =
+//       UniquePath(prefix ++ path)
+
+//     def children = Nil
+//   }
+
+//   /**
+//     * Reifies a traversal from a Cursor to multiple, possibly nullable, values.
+//     *
+//     * Typically such a path would use used to identify the list of values of
+//     * an attribute of the object elements of a list field of the object or
+//     * interface at the focus of the cursor, to be tested via a predicate such
+//     * as `In`.
+//     */
+//   case class ListPath[T](val path: List[String]) extends Term[List[T]] with Path {
+//     def apply(c: Cursor): Result[List[T]] =
+//       c.flatListPath(path).map(_.map {
+//         case ScalarFocus(f: T @unchecked) => f
+//         case _ => sys.error("impossible")
+//       })
+
+//     def prepend(prefix: List[String]): Path =
+//       ListPath(prefix ++ path)
+
+//     def children = Nil
+//   }
+// }
 
 trait Predicate extends Term[Boolean]
 

--- a/modules/core/src/main/scala/predicate.scala
+++ b/modules/core/src/main/scala/predicate.scala
@@ -71,13 +71,13 @@ object Path {
 
 }
 
-sealed trait PathTerm[A] extends Term[A] {
+sealed trait PathTerm {
   def children: List[Term[_]] =  Nil
   def path: List[String]
 }
 object PathTerm {
 
-  case class ListPath[A](path: List[String]) extends PathTerm[A] {
+  case class ListPath[A](path: List[String]) extends Term[A] with PathTerm {
     def apply(c: Cursor): Result[A] =
       c.flatListPath(path).map(_.map {
         case Predicate.ScalarFocus(f) => f
@@ -85,7 +85,7 @@ object PathTerm {
       } .asInstanceOf[A])
   }
 
-  case class UniquePath[A](path: List[String]) extends PathTerm[A] {
+  case class UniquePath[A](path: List[String]) extends Term[A] with PathTerm {
     def apply(c: Cursor): Result[A] =
       c.listPath(path) match {
         case Ior.Right(List(Predicate.ScalarFocus(a: A @unchecked))) => a.rightIor

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -206,7 +206,7 @@ sealed trait Type extends Product {
    * path passes through at least one field of a List type.
    */
   def pathIsList(fns: List[String]): Boolean = (fns, this) match {
-    case (Nil, _) => false
+    case (Nil, _) => this.isList
     case (_, _: ListType) => true
     case (_, NullableType(tpe)) => tpe.pathIsList(fns)
     case (_, TypeRef(_, _)) => dealias.pathIsList(fns)
@@ -408,6 +408,10 @@ sealed trait Type extends Product {
   def isInterface: Boolean = false
 
   def isUnion: Boolean = false
+
+  def /(pathElement: String): Path =
+    Path.from(this) / pathElement
+
 }
 
 // Move all below into object Type?
@@ -455,6 +459,7 @@ case class TypeRef(schema: Schema, name: String) extends NamedType {
   override lazy val exists: Boolean = schema.definition(name).isDefined
 
   def description: Option[String] = dealias.description
+
 }
 
 /**

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -10,7 +10,7 @@ import cats.tests.CatsSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._, UntypedOperation._
+import Query._, Predicate._, Value._, UntypedOperation._
 import QueryCompiler._, ComponentElaborator.TrivialJoin
 import QueryInterpreter.mkOneError
 
@@ -201,8 +201,8 @@ final class CompilerSuite extends CatsSuite {
       Select(
         "character", Nil,
         Unique(
-          Filter(Eql(UniquePath(List("id")), Const("1000")),
-            Select("name", Nil) ~
+          Filter(Eql(AtomicMapping.CharacterType / "id", Const("1000")),
+          Select("name", Nil) ~
               Select(
                 "friends", Nil,
                 Select("name", Nil)
@@ -387,9 +387,7 @@ final class CompilerSuite extends CatsSuite {
     val res = QueryParser.parseText(query)
 
     val error =
-      """Parse error at line 5 column 4
-        |    
-        |    ^""".stripMargin
+      "Parse error at line 5 column 4\n    \n    ^"
 
     assert(res == Ior.Left(mkOneError(error)))
   }
@@ -409,13 +407,14 @@ object AtomicMapping extends Mapping[Id] {
     """
 
   val QueryType = schema.ref("Query")
+  val CharacterType = schema.ref("Character")
 
   val typeMappings = Nil
 
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("character", List(Binding("id", StringValue(id))), child) =>
-        Select("character", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("character", Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).rightIor
     }
   ))
 }

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -10,7 +10,7 @@ import cats.tests.CatsSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 final class FragmentSuite extends CatsSuite {
@@ -37,7 +37,7 @@ final class FragmentSuite extends CatsSuite {
     val expected =
       Select("user", Nil,
         Unique(
-          Filter(Eql(UniquePath(List("id")), Const("1")),
+          Filter(Eql(FragmentMapping.UserType / "id", Const("1")),
             Group(List(
               Select("friends", Nil,
                 Group(List(
@@ -127,7 +127,7 @@ final class FragmentSuite extends CatsSuite {
     val expected =
       Select("user", Nil,
         Unique(
-          Filter(Eql(UniquePath(List("id")), Const("1")),
+          Filter(Eql(FragmentMapping.UserType / "id", Const("1")),
             Group(List(
               Select("friends", Nil,
                 Group(List(
@@ -369,7 +369,7 @@ final class FragmentSuite extends CatsSuite {
       Group(List(
         Select("user", Nil,
           Unique(
-            Filter(Eql(UniquePath(List("id")), Const("1")),
+            Filter(Eql(FragmentMapping.UserType / "id", Const("1")),
               Select("favourite", Nil,
                 Group(List(
                   Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
@@ -387,7 +387,7 @@ final class FragmentSuite extends CatsSuite {
         ),
         Rename("page", Select("user", Nil,
           Unique(
-            Filter(Eql(UniquePath(List("id")), Const("2")),
+            Filter(Eql(FragmentMapping.PageType / "id", Const("2")),
               Select("favourite", Nil,
                 Group(List(
                   Introspect(FragmentMapping.schema, Select("__typename", Nil, Empty)),
@@ -454,7 +454,7 @@ final class FragmentSuite extends CatsSuite {
     val expected =
       Select("user", Nil,
         Unique(
-          Filter(Eql(UniquePath(List("id")), Const("1")),
+          Filter(Eql(FragmentMapping.UserType / "id", Const("1")),
             Select("friends", Nil,
               Select("id", Nil, Empty)
             )
@@ -698,7 +698,7 @@ object FragmentMapping extends ValueMapping[Id] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("user", List(Binding("id", IDValue(id))), child) =>
-        Select("user", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("user", Nil, Unique(Filter(Eql(FragmentMapping.UserType / "id", Const(id)), child))).rightIor
       case sel@Select("profiles", _, _) =>
         sel.rightIor
     }

--- a/modules/core/src/test/scala/compiler/Predicates.scala
+++ b/modules/core/src/test/scala/compiler/Predicates.scala
@@ -9,7 +9,7 @@ import cats.tests.CatsSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 object ItemData {
@@ -71,13 +71,13 @@ object ItemMapping extends ValueMapping[Id] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("itemByTag", List(Binding("tag", IDValue(tag))), child) =>
-        Select("itemByTag", Nil, Filter(Contains(ListPath(List("tags")), Const(tag)), child)).rightIor
+        Select("itemByTag", Nil, Filter(Contains(ItemType / "tags", Const(tag)), child)).rightIor
       case Select("itemByTagCount", List(Binding("count", IntValue(count))), child) =>
-        Select("itemByTagCount", Nil, Filter(Eql(UniquePath(List("tagCount")), Const(count)), child)).rightIor
+        Select("itemByTagCount", Nil, Filter(Eql(ItemType / "tagCount", Const(count)), child)).rightIor
       case Select("itemByTagCountVA", List(Binding("count", IntValue(count))), child) =>
-        Select("itemByTagCountVA", Nil, Filter(Eql(UniquePath(List("tagCountVA")), Const(count)), child)).rightIor
+        Select("itemByTagCountVA", Nil, Filter(Eql(ItemType / "tagCountVA", Const(count)), child)).rightIor
       case Select("itemByTagCountCA", List(Binding("count", IntValue(count))), child) =>
-        Select("itemByTagCountCA", Nil, Filter(Eql(UniquePath(List("tagCountCA")), Const(count)), child)).rightIor
+        Select("itemByTagCountCA", Nil, Filter(Eql(ItemType / "tagCountCA", Const(count)), child)).rightIor
     }
   ))
 }

--- a/modules/core/src/test/scala/compiler/ScalarsSpec.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSpec.scala
@@ -13,7 +13,7 @@ import cats.tests.CatsSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 import io.circe.Encoder
@@ -193,15 +193,15 @@ object MovieMapping extends ValueMapping[Id] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("movieById", List(Binding("id", UUIDValue(id))), child) =>
-        Select("movieById", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("movieById", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).rightIor
       case Select("moviesByGenre", List(Binding("genre", GenreValue(genre))), child) =>
-        Select("moviesByGenre", Nil, Filter(Eql(UniquePath(List("genre")), Const(genre)), child)).rightIor
+        Select("moviesByGenre", Nil, Filter(Eql(MovieType / "genre", Const(genre)), child)).rightIor
       case Select("moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to))), child) =>
         Select("moviesReleasedBetween", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("releaseDate")), Const(from))),
-              Lt(UniquePath(List("releaseDate")), Const(to))
+              Not(Lt(MovieType / "releaseDate", Const(from))),
+              Lt(MovieType / "releaseDate", Const(to))
             ),
             child
           )
@@ -209,14 +209,14 @@ object MovieMapping extends ValueMapping[Id] {
       case Select("moviesLongerThan", List(Binding("duration", IntervalValue(duration))), child) =>
         Select("moviesLongerThan", Nil,
           Filter(
-            Not(Lt(UniquePath(List("duration")), Const(duration))),
+            Not(Lt(MovieType / "duration", Const(duration))),
             child
           )
         ).rightIor
       case Select("moviesShownLaterThan", List(Binding("time", TimeValue(time))), child) =>
         Select("moviesShownLaterThan", Nil,
           Filter(
-            Not(Lt(UniquePath(List("showTime")), Const(time))),
+            Not(Lt(MovieType / "showTime", Const(time))),
             child
           )
         ).rightIor
@@ -224,8 +224,8 @@ object MovieMapping extends ValueMapping[Id] {
         Select("moviesShownBetween", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("nextShowing")), Const(from))),
-              Lt(UniquePath(List("nextShowing")), Const(to))
+              Not(Lt(MovieType / "nextShowing", Const(from))),
+              Lt(MovieType / "nextShowing", Const(to))
             ),
             child
           )

--- a/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
@@ -1,1504 +1,1504 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-// package introspection
-
-// import cats.Id
-// import cats.tests.CatsSuite
-// import io.circe.{ ACursor, Json }
-
-// import edu.gemini.grackle._
-// import edu.gemini.grackle.syntax._
-// import QueryCompiler.IntrospectionLevel
-// import IntrospectionLevel._
-
-// final class IntrospectionSuite extends CatsSuite {
-//   def standardTypeName(name: String): Boolean = name match {
-//     case "Int" | "Float" | "Boolean" | "String" | "ID" => true
-//     case _ => name.startsWith("__")
-//   }
-
-//   implicit class ACursorOps(self: ACursor) {
-//     def filterArray(f: Json => Boolean): ACursor = {
-//       def go(ac: ACursor, i: Int = 0): ACursor = {
-//         val acʹ = ac.downN(i)
-//         acʹ.focus match {
-//           case None    => ac
-//           case Some(j) => if (f(j)) go(ac, i + 1) else go(acʹ.delete, i)
-//         }
-//       }
-//       go(self)
-//     }
-//   }
-
-//   def stripStandardTypes(result: Json): Json =
-//     result
-//       .hcursor
-//       .downField("data")
-//       .downField("__schema")
-//       .downField("types")
-//       .filterArray(_.hcursor.downField("name").as[String].exists(!standardTypeName(_)))
-//       .top // .root doesn't work in 0.13
-//       .getOrElse(sys.error("stripStandardTypes failed"))
-
-//   test("simple type query") {
-//     val query = """
-//       {
-//         __type(name: "User") {
-//           name
-//           fields {
-//             name
-//             type {
-//               name
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type": {
-//             "name": "User",
-//             "fields": [
-//               {
-//                 "name": "id",
-//                 "type": { "name": "String" }
-//               },
-//               {
-//                 "name": "name",
-//                 "type": { "name": "String" }
-//               },
-//               {
-//                 "name": "birthday",
-//                 "type": { "name": "Date" }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("kind/name/description/ofType query") {
-//     val query = """
-//       {
-//         __type(name: "KindTest") {
-//           name
-//           description
-//           fields {
-//             name
-//             description
-//             type {
-//               kind
-//               name
-//               description
-//               ofType {
-//                 kind
-//                 name
-//                 description
-//                 ofType {
-//                   kind
-//                   name
-//                   description
-//                   ofType {
-//                     kind
-//                     name
-//                     description
-//                   }
-//                 }
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "name" : "KindTest",
-//             "description" : null,
-//             "fields" : [
-//               {
-//                 "name" : "scalar",
-//                 "description" : "Scalar field",
-//                 "type" : {
-//                   "kind" : "SCALAR",
-//                   "name" : "Int",
-//                   "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
-//                   "ofType" : null
-//                 }
-//               },
-//               {
-//                 "name" : "object",
-//                 "description" : "Object field",
-//                 "type" : {
-//                   "kind" : "OBJECT",
-//                   "name" : "User",
-//                   "description" : "User object type",
-//                   "ofType" : null
-//                 }
-//               },
-//               {
-//                 "name" : "interface",
-//                 "description" : "Interface field",
-//                 "type" : {
-//                   "kind" : "INTERFACE",
-//                   "name" : "Profile",
-//                   "description" : "Profile interface type",
-//                   "ofType" : null
-//                 }
-//               },
-//               {
-//                 "name" : "union",
-//                 "description" : "Union field",
-//                 "type" : {
-//                   "kind" : "UNION",
-//                   "name" : "Choice",
-//                   "description" : "Choice union type",
-//                   "ofType" : null
-//                 }
-//               },
-//               {
-//                 "name" : "enum",
-//                 "description" : "Enum field",
-//                 "type" : {
-//                   "kind" : "ENUM",
-//                   "name" : "Flags",
-//                   "description" : "Flags enum type",
-//                   "ofType" : null
-//                 }
-//               },
-//               {
-//                 "name" : "list",
-//                 "description" : "List field",
-//                 "type" : {
-//                   "kind" : "LIST",
-//                   "name" : null,
-//                   "description" : null,
-//                   "ofType" : {
-//                     "kind" : "SCALAR",
-//                     "name" : "Int",
-//                     "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
-//                     "ofType" : null
-//                   }
-//                 }
-//               },
-//               {
-//                 "name" : "nonnull",
-//                 "description" : "Nonnull field",
-//                 "type" : {
-//                   "kind" : "NON_NULL",
-//                   "name" : null,
-//                   "description" : null,
-//                   "ofType" : {
-//                     "kind" : "SCALAR",
-//                     "name" : "Int",
-//                     "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
-//                     "ofType" : null
-//                   }
-//                 }
-//               },
-//               {
-//                 "name" : "nonnulllistnonnull",
-//                 "description" : "Nonnull list of nonnull field",
-//                 "type" : {
-//                   "kind" : "NON_NULL",
-//                   "name" : null,
-//                   "description" : null,
-//                   "ofType" : {
-//                     "kind" : "LIST",
-//                     "name" : null,
-//                     "description" : null,
-//                     "ofType" : {
-//                       "kind" : "NON_NULL",
-//                       "name" : null,
-//                       "description" : null,
-//                       "ofType" : {
-//                         "kind" : "SCALAR",
-//                         "name" : "Int",
-//                         "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar."
-//                       }
-//                     }
-//                   }
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("fields query") {
-//     val query = """
-//       {
-//         __type(name: "KindTest") {
-//           name
-//           fields {
-//             name
-//             type {
-//               name
-//               fields {
-//                 name
-//                 type {
-//                   name
-//                 }
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "name" : "KindTest",
-//             "fields" : [
-//               {
-//                 "name" : "scalar",
-//                 "type" : {
-//                   "name" : "Int",
-//                   "fields" : null
-//                 }
-//               },
-//               {
-//                 "name" : "object",
-//                 "type" : {
-//                   "name" : "User",
-//                   "fields" : [
-//                     {
-//                       "name" : "id",
-//                       "type" : {
-//                         "name" : "String"
-//                       }
-//                     },
-//                     {
-//                       "name" : "name",
-//                       "type" : {
-//                         "name" : "String"
-//                       }
-//                     },
-//                     {
-//                       "name" : "birthday",
-//                       "type" : {
-//                         "name" : "Date"
-//                       }
-//                     }
-//                   ]
-//                 }
-//               },
-//               {
-//                 "name" : "interface",
-//                 "type" : {
-//                   "name" : "Profile",
-//                   "fields" : [
-//                     {
-//                       "name" : "id",
-//                       "type" : {
-//                         "name" : "String"
-//                       }
-//                     }
-//                   ]
-//                 }
-//               },
-//               {
-//                 "name" : "union",
-//                 "type" : {
-//                   "name" : "Choice",
-//                   "fields" : null
-//                 }
-//               },
-//               {
-//                 "name" : "enum",
-//                 "type" : {
-//                   "name" : "Flags",
-//                   "fields" : null
-//                 }
-//               },
-//               {
-//                 "name" : "list",
-//                 "type" : {
-//                   "name" : null,
-//                   "fields" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnull",
-//                 "type" : {
-//                   "name" : null,
-//                   "fields" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnulllistnonnull",
-//                 "type" : {
-//                   "name" : null,
-//                   "fields" : null
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("interfaces query") {
-//     val query = """
-//       {
-//         __type(name: "KindTest") {
-//           name
-//           fields {
-//             name
-//             type {
-//               interfaces {
-//                 name
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "name" : "KindTest",
-//             "fields" : [
-//               {
-//                 "name" : "scalar",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               },
-//               {
-//                 "name" : "object",
-//                 "type" : {
-//                   "interfaces" : [
-//                     {
-//                       "name" : "Profile"
-//                     }
-//                   ]
-//                 }
-//               },
-//               {
-//                 "name" : "interface",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               },
-//               {
-//                 "name" : "union",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               },
-//               {
-//                 "name" : "enum",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               },
-//               {
-//                 "name" : "list",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnull",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnulllistnonnull",
-//                 "type" : {
-//                   "interfaces" : null
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("possibleTypes query") {
-//     val query = """
-//       {
-//         __type(name: "KindTest") {
-//           name
-//           fields {
-//             name
-//             type {
-//               possibleTypes {
-//                 name
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "name" : "KindTest",
-//             "fields" : [
-//               {
-//                 "name" : "scalar",
-//                 "type" : {
-//                   "possibleTypes" : null
-//                 }
-//               },
-//               {
-//                 "name" : "object",
-//                 "type" : {
-//                   "possibleTypes" : null
-//                 }
-//               },
-//               {
-//                 "name" : "interface",
-//                 "type" : {
-//                   "possibleTypes" : [
-//                     {
-//                       "name" : "User"
-//                     }
-//                   ]
-//                 }
-//               },
-//               {
-//                 "name" : "union",
-//                 "type" : {
-//                   "possibleTypes" : [
-//                     {
-//                       "name" : "User"
-//                     },
-//                     {
-//                       "name" : "Date"
-//                     }
-//                   ]
-//                 }
-//               },
-//               {
-//                 "name" : "enum",
-//                 "type" : {
-//                   "possibleTypes" : null
-//                 }
-//               },
-//               {
-//                 "name" : "list",
-//                 "type" : {
-//                   "possibleTypes" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnull",
-//                 "type" : {
-//                   "possibleTypes" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnulllistnonnull",
-//                 "type" : {
-//                   "possibleTypes" : null
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("enumValues query") {
-//     val query = """
-//       {
-//         __type(name: "KindTest") {
-//           name
-//           fields {
-//             name
-//             type {
-//               enumValues {
-//                 name
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "name" : "KindTest",
-//             "fields" : [
-//               {
-//                 "name" : "scalar",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "object",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "interface",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "union",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "enum",
-//                 "type" : {
-//                   "enumValues" : [
-//                     {
-//                       "name" : "A"
-//                     },
-//                     {
-//                       "name" : "C"
-//                     }
-//                   ]
-//                 }
-//               },
-//               {
-//                 "name" : "list",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnull",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "nonnulllistnonnull",
-//                 "type" : {
-//                   "enumValues" : null
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("deprecation excluded") {
-//     val query = """
-//       {
-//         __type(name: "DeprecationTest") {
-//           fields {
-//             name
-//             type {
-//               fields(includeDeprecated: false) {
-//                 name
-//                 isDeprecated
-//                 deprecationReason
-//               }
-//               enumValues(includeDeprecated: false) {
-//                 name
-//                 isDeprecated
-//                 deprecationReason
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "fields" : [
-//               {
-//                 "name" : "user",
-//                 "type" : {
-//                   "fields" : [
-//                     {
-//                       "name" : "id",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     },
-//                     {
-//                       "name" : "name",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     },
-//                     {
-//                       "name" : "birthday",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     }
-//                   ],
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "flags",
-//                 "type" : {
-//                   "fields" : null,
-//                   "enumValues" : [
-//                     {
-//                       "name" : "A",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     },
-//                     {
-//                       "name" : "C",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     }
-//                   ]
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("deprecation included") {
-//     val query = """
-//       {
-//         __type(name: "DeprecationTest") {
-//           fields {
-//             name
-//             type {
-//               fields(includeDeprecated: true) {
-//                 name
-//                 isDeprecated
-//                 deprecationReason
-//               }
-//               enumValues(includeDeprecated: true) {
-//                 name
-//                 isDeprecated
-//                 deprecationReason
-//               }
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__type" : {
-//             "fields" : [
-//               {
-//                 "name" : "user",
-//                 "type" : {
-//                   "fields" : [
-//                     {
-//                       "name" : "id",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     },
-//                     {
-//                       "name" : "name",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     },
-//                     {
-//                       "name" : "age",
-//                       "isDeprecated" : true,
-//                       "deprecationReason" : "Use birthday instead"
-//                     },
-//                     {
-//                       "name" : "birthday",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     }
-//                   ],
-//                   "enumValues" : null
-//                 }
-//               },
-//               {
-//                 "name" : "flags",
-//                 "type" : {
-//                   "fields" : null,
-//                   "enumValues" : [
-//                     {
-//                       "name" : "A",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     },
-//                     {
-//                       "name" : "B",
-//                       "isDeprecated" : true,
-//                       "deprecationReason" : "Deprecation test"
-//                     },
-//                     {
-//                       "name" : "C",
-//                       "isDeprecated" : false,
-//                       "deprecationReason" : null
-//                     }
-//                   ]
-//                 }
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("simple schema query") {
-//     val query = """
-//       {
-//         __schema {
-//           queryType { name }
-//           mutationType { name }
-//           subscriptionType { name }
-//           types { name }
-//           directives { name }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__schema" : {
-//             "queryType" : {
-//               "name" : "Query"
-//             },
-//             "mutationType" : null,
-//             "subscriptionType" : null,
-//             "types" : [
-//               {
-//                 "name" : "Query"
-//               },
-//               {
-//                 "name" : "User"
-//               },
-//               {
-//                 "name" : "Profile"
-//               },
-//               {
-//                 "name" : "Date"
-//               },
-//               {
-//                 "name" : "Choice"
-//               },
-//               {
-//                 "name" : "Flags"
-//               },
-//               {
-//                 "name" : "KindTest"
-//               },
-//               {
-//                 "name" : "DeprecationTest"
-//               }
-//             ],
-//             "directives" : [
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res0 = TestMapping.compileAndRun(query)
-//     val res = stripStandardTypes(res0)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("standard introspection query") {
-//     val query = """
-//       |query IntrospectionQuery {
-//       |  __schema {
-//       |    queryType { name }
-//       |    mutationType { name }
-//       |    subscriptionType { name }
-//       |    types {
-//       |      ...FullType
-//       |    }
-//       |    directives {
-//       |      name
-//       |      description
-//       |      locations
-//       |      args {
-//       |        ...InputValue
-//       |      }
-//       |    }
-//       |  }
-//       |}
-//       |
-//       |fragment FullType on __Type {
-//       |  kind
-//       |  name
-//       |  description
-//       |  fields(includeDeprecated: true) {
-//       |    name
-//       |    description
-//       |    args {
-//       |      ...InputValue
-//       |    }
-//       |    type {
-//       |      ...TypeRef
-//       |    }
-//       |    isDeprecated
-//       |    deprecationReason
-//       |  }
-//       |  inputFields {
-//       |    ...InputValue
-//       |  }
-//       |  interfaces {
-//       |    ...TypeRef
-//       |  }
-//       |  enumValues(includeDeprecated: true) {
-//       |    name
-//       |    description
-//       |    isDeprecated
-//       |    deprecationReason
-//       |  }
-//       |  possibleTypes {
-//       |    ...TypeRef
-//       |  }
-//       |}
-//       |
-//       |fragment InputValue on __InputValue {
-//       |  name
-//       |  description
-//       |  type { ...TypeRef }
-//       |  defaultValue
-//       |}
-//       |
-//       |fragment TypeRef on __Type {
-//       |  kind
-//       |  name
-//       |  ofType {
-//       |    kind
-//       |    name
-//       |    ofType {
-//       |      kind
-//       |      name
-//       |      ofType {
-//       |        kind
-//       |        name
-//       |        ofType {
-//       |          kind
-//       |          name
-//       |          ofType {
-//       |            kind
-//       |            name
-//       |            ofType {
-//       |              kind
-//       |              name
-//       |              ofType {
-//       |                kind
-//       |                name
-//       |              }
-//       |            }
-//       |          }
-//       |        }
-//       |      }
-//       |    }
-//       |  }
-//       |}
-//     """.stripMargin.trim
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "__schema" : {
-//             "queryType" : {
-//               "name" : "Query"
-//             },
-//             "mutationType" : {
-//               "name" : "Mutation"
-//             },
-//             "subscriptionType" : {
-//               "name" : "Subscription"
-//             },
-//             "types" : [
-//               {
-//                 "kind" : "OBJECT",
-//                 "name" : "Query",
-//                 "description" : null,
-//                 "fields" : [
-//                   {
-//                     "name" : "users",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "NON_NULL",
-//                       "name" : null,
-//                       "ofType" : {
-//                         "kind" : "LIST",
-//                         "name" : null,
-//                         "ofType" : {
-//                           "kind" : "NON_NULL",
-//                           "name" : null,
-//                           "ofType" : {
-//                             "kind" : "OBJECT",
-//                             "name" : "User",
-//                             "ofType" : null
-//                           }
-//                         }
-//                       }
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   },
-//                   {
-//                     "name" : "profiles",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "NON_NULL",
-//                       "name" : null,
-//                       "ofType" : {
-//                         "kind" : "LIST",
-//                         "name" : null,
-//                         "ofType" : {
-//                           "kind" : "NON_NULL",
-//                           "name" : null,
-//                           "ofType" : {
-//                             "kind" : "INTERFACE",
-//                             "name" : "Profile",
-//                             "ofType" : null
-//                           }
-//                         }
-//                       }
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   }
-//                 ],
-//                 "inputFields" : null,
-//                 "interfaces" : [
-//                 ],
-//                 "enumValues" : null,
-//                 "possibleTypes" : null
-//               },
-//               {
-//                 "kind" : "OBJECT",
-//                 "name" : "Subscription",
-//                 "description" : null,
-//                 "fields" : [
-//                   {
-//                     "name" : "dummy",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "NON_NULL",
-//                       "name" : null,
-//                       "ofType" : {
-//                         "kind" : "SCALAR",
-//                         "name" : "Int",
-//                         "ofType" : null
-//                       }
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   }
-//                 ],
-//                 "inputFields" : null,
-//                 "interfaces" : [
-//                 ],
-//                 "enumValues" : null,
-//                 "possibleTypes" : null
-//               },
-//               {
-//                 "kind" : "OBJECT",
-//                 "name" : "Mutation",
-//                 "description" : null,
-//                 "fields" : [
-//                   {
-//                     "name" : "dummy",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "NON_NULL",
-//                       "name" : null,
-//                       "ofType" : {
-//                         "kind" : "SCALAR",
-//                         "name" : "Int",
-//                         "ofType" : null
-//                       }
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   }
-//                 ],
-//                 "inputFields" : null,
-//                 "interfaces" : [
-//                 ],
-//                 "enumValues" : null,
-//                 "possibleTypes" : null
-//               },
-//               {
-//                 "kind" : "INTERFACE",
-//                 "name" : "Profile",
-//                 "description" : "Profile interface type",
-//                 "fields" : [
-//                   {
-//                     "name" : "id",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "SCALAR",
-//                       "name" : "String",
-//                       "ofType" : null
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   }
-//                 ],
-//                 "inputFields" : null,
-//                 "interfaces" : null,
-//                 "enumValues" : null,
-//                 "possibleTypes" : [
-//                   {
-//                     "kind" : "OBJECT",
-//                     "name" : "User",
-//                     "ofType" : null
-//                   }
-//                 ]
-//               },
-//               {
-//                 "kind" : "OBJECT",
-//                 "name" : "User",
-//                 "description" : "User object type",
-//                 "fields" : [
-//                   {
-//                     "name" : "id",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "SCALAR",
-//                       "name" : "String",
-//                       "ofType" : null
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   },
-//                   {
-//                     "name" : "name",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "SCALAR",
-//                       "name" : "String",
-//                       "ofType" : null
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   },
-//                   {
-//                     "name" : "age",
-//                     "description" : null,
-//                     "args" : [
-//                     ],
-//                     "type" : {
-//                       "kind" : "SCALAR",
-//                       "name" : "Int",
-//                       "ofType" : null
-//                     },
-//                     "isDeprecated" : false,
-//                     "deprecationReason" : null
-//                   }
-//                 ],
-//                 "inputFields" : null,
-//                 "interfaces" : [
-//                   {
-//                     "kind" : "INTERFACE",
-//                     "name" : "Profile",
-//                     "ofType" : null
-//                   }
-//                 ],
-//                 "enumValues" : null,
-//                 "possibleTypes" : null
-//               }
-//             ],
-//             "directives" : [
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res0 = SmallMapping.compileAndRun(query)
-//     val res = stripStandardTypes(res0)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("typename query") {
-//     val query = """
-//       {
-//         users {
-//           __typename
-//           renamed: __typename
-//           name
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "users" : [
-//             {
-//               "__typename" : "User",
-//               "renamed" : "User",
-//               "name" : "Luke Skywalker"
-//             }
-//           ]
-//         }
-//       }
-//     """
-
-//     val res = SmallMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("typename query with narrowing") {
-//     val query = """
-//       {
-//         profiles {
-//           __typename
-//           id
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "profiles" : [
-//             {
-//               "__typename" : "User",
-//               "id" : "1000"
-//             }
-//           ]
-//         }
-//       }
-//     """
-
-//     val res = SmallMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("mixed query") {
-//     val query = """
-//       {
-//         users {
-//           name
-//         }
-//         __type(name: "User") {
-//           name
-//           fields {
-//             name
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "users" : [
-//             {
-//               "name" : "Luke Skywalker"
-//             }
-//           ],
-//           "__type" : {
-//             "name": "User",
-//             "fields" : [
-//               {
-//                 "name" : "id"
-//               },
-//               {
-//                 "name" : "name"
-//               },
-//               {
-//                 "name" : "age"
-//               }
-//             ]
-//           }
-//         }
-//       }
-//     """
-
-//     val res = SmallMapping.compileAndRun(query)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("introspection disabled") {
-//     val query = """
-//       {
-//         __type(name: "User") {
-//           name
-//           fields {
-//             name
-//             type {
-//               name
-//             }
-//           }
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "errors" : [
-//           {
-//             "message" : "Unknown field '__type' in 'Query'"
-//           }
-//         ]
-//       }
-//     """
-
-//     val res = TestMapping.compileAndRun(query, introspectionLevel = Disabled)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-
-//   test("introspection disabled typename allowed") {
-//     val query = """
-//       {
-//         users {
-//           __typename
-//           renamed: __typename
-//           name
-//         }
-//       }
-//     """
-
-//     val expected = json"""
-//       {
-//         "data" : {
-//           "users" : [
-//             {
-//               "__typename" : "User",
-//               "renamed" : "User",
-//               "name" : "Luke Skywalker"
-//             }
-//           ]
-//         }
-//       }
-//     """
-
-//     val res = SmallMapping.compileAndRun(query, introspectionLevel = TypenameOnly)
-//     //println(res)
-
-//     assert(res == expected)
-//   }
-// }
-
-// object TestMapping extends Mapping[Id] {
-//   val schema =
-//     schema"""
-//       type Query {
-//         users: [User!]!
-//       }
-
-//       "User object type"
-//       type User implements Profile {
-//         id: String
-//         name: String
-//         age: Int @deprecated(reason: "Use birthday instead")
-//         birthday: Date
-//       }
-
-//       "Profile interface type"
-//       interface Profile {
-//         id: String
-//       }
-
-//       "Date object type"
-//       type Date {
-//         day: Int
-//         month: Int
-//         year: Int
-//       }
-
-//       "Choice union type"
-//       union Choice = User | Date
-
-//       "Flags enum type"
-//       enum Flags {
-//         A
-//         B @deprecated(reason: "Deprecation test")
-//         C
-//       }
-
-//       type KindTest {
-//         "Scalar field"
-//         scalar: Int
-//         "Object field"
-//         object: User
-//         "Interface field"
-//         interface: Profile
-//         "Union field"
-//         union: Choice
-//         "Enum field"
-//         enum: Flags
-//         "List field"
-//         list: [Int]
-//         "Nonnull field"
-//         nonnull: Int!
-//         "Nonnull list of nonnull field"
-//         nonnulllistnonnull: [Int!]!
-//       }
-
-//       type DeprecationTest {
-//         user: User
-//         flags: Flags
-//       }
-//     """
-
-//   val typeMappings = Nil
-// }
-
-// object SmallData {
-//   trait Profile {
-//     def id: Option[String]
-//   }
-//   case class User(id: Option[String], name: Option[String], age: Option[Int]) extends Profile
-//   val users = List(
-//     User(Some("1000"), Some("Luke Skywalker"), Some(30))
-//   )
-// }
-
-// object SmallMapping extends ValueMapping[Id] {
-//   import SmallData._
-
-//   val schema =
-//     schema"""
-//       type Query {
-//         users: [User!]!
-//         profiles: [Profile!]!
-//       }
-//       type Subscription {
-//         dummy: Int!
-//       }
-//       type Mutation {
-//         dummy: Int!
-//       }
-//       "Profile interface type"
-//       interface Profile {
-//         id: String
-//       }
-//       "User object type"
-//       type User implements Profile {
-//         id: String
-//         name: String
-//         age: Int
-//       }
-//     """
-
-//   val QueryType = schema.queryType
-//   val UserType = schema.ref("User")
-//   val ProfileType = schema.ref("Profile")
-
-//   val typeMappings =
-//     List(
-//       ObjectMapping(
-//         tpe = QueryType,
-//         fieldMappings =
-//           List(
-//             ValueRoot("users", users),
-//             ValueRoot("profiles", users)
-//           )
-//       ),
-//       ValueObjectMapping[User](
-//         tpe = UserType,
-//         fieldMappings =
-//           List(
-//             ValueField("name", _.name),
-//             ValueField("age", _.age)
-//           )
-//       ),
-//       ValueObjectMapping[Profile](
-//         tpe = ProfileType,
-//         fieldMappings =
-//           List(
-//             ValueField("id", _.id)
-//           )
-//       )
-//   )
-// }
+package introspection
+
+import cats.Id
+import cats.tests.CatsSuite
+import io.circe.{ ACursor, Json }
+
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import QueryCompiler.IntrospectionLevel
+import IntrospectionLevel._
+
+final class IntrospectionSuite extends CatsSuite {
+  def standardTypeName(name: String): Boolean = name match {
+    case "Int" | "Float" | "Boolean" | "String" | "ID" => true
+    case _ => name.startsWith("__")
+  }
+
+  implicit class ACursorOps(self: ACursor) {
+    def filterArray(f: Json => Boolean): ACursor = {
+      def go(ac: ACursor, i: Int = 0): ACursor = {
+        val acʹ = ac.downN(i)
+        acʹ.focus match {
+          case None    => ac
+          case Some(j) => if (f(j)) go(ac, i + 1) else go(acʹ.delete, i)
+        }
+      }
+      go(self)
+    }
+  }
+
+  def stripStandardTypes(result: Json): Json =
+    result
+      .hcursor
+      .downField("data")
+      .downField("__schema")
+      .downField("types")
+      .filterArray(_.hcursor.downField("name").as[String].exists(!standardTypeName(_)))
+      .top // .root doesn't work in 0.13
+      .getOrElse(sys.error("stripStandardTypes failed"))
+
+  test("simple type query") {
+    val query = """
+      {
+        __type(name: "User") {
+          name
+          fields {
+            name
+            type {
+              name
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type": {
+            "name": "User",
+            "fields": [
+              {
+                "name": "id",
+                "type": { "name": "String" }
+              },
+              {
+                "name": "name",
+                "type": { "name": "String" }
+              },
+              {
+                "name": "birthday",
+                "type": { "name": "Date" }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("kind/name/description/ofType query") {
+    val query = """
+      {
+        __type(name: "KindTest") {
+          name
+          description
+          fields {
+            name
+            description
+            type {
+              kind
+              name
+              description
+              ofType {
+                kind
+                name
+                description
+                ofType {
+                  kind
+                  name
+                  description
+                  ofType {
+                    kind
+                    name
+                    description
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "name" : "KindTest",
+            "description" : null,
+            "fields" : [
+              {
+                "name" : "scalar",
+                "description" : "Scalar field",
+                "type" : {
+                  "kind" : "SCALAR",
+                  "name" : "Int",
+                  "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
+                  "ofType" : null
+                }
+              },
+              {
+                "name" : "object",
+                "description" : "Object field",
+                "type" : {
+                  "kind" : "OBJECT",
+                  "name" : "User",
+                  "description" : "User object type",
+                  "ofType" : null
+                }
+              },
+              {
+                "name" : "interface",
+                "description" : "Interface field",
+                "type" : {
+                  "kind" : "INTERFACE",
+                  "name" : "Profile",
+                  "description" : "Profile interface type",
+                  "ofType" : null
+                }
+              },
+              {
+                "name" : "union",
+                "description" : "Union field",
+                "type" : {
+                  "kind" : "UNION",
+                  "name" : "Choice",
+                  "description" : "Choice union type",
+                  "ofType" : null
+                }
+              },
+              {
+                "name" : "enum",
+                "description" : "Enum field",
+                "type" : {
+                  "kind" : "ENUM",
+                  "name" : "Flags",
+                  "description" : "Flags enum type",
+                  "ofType" : null
+                }
+              },
+              {
+                "name" : "list",
+                "description" : "List field",
+                "type" : {
+                  "kind" : "LIST",
+                  "name" : null,
+                  "description" : null,
+                  "ofType" : {
+                    "kind" : "SCALAR",
+                    "name" : "Int",
+                    "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
+                    "ofType" : null
+                  }
+                }
+              },
+              {
+                "name" : "nonnull",
+                "description" : "Nonnull field",
+                "type" : {
+                  "kind" : "NON_NULL",
+                  "name" : null,
+                  "description" : null,
+                  "ofType" : {
+                    "kind" : "SCALAR",
+                    "name" : "Int",
+                    "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
+                    "ofType" : null
+                  }
+                }
+              },
+              {
+                "name" : "nonnulllistnonnull",
+                "description" : "Nonnull list of nonnull field",
+                "type" : {
+                  "kind" : "NON_NULL",
+                  "name" : null,
+                  "description" : null,
+                  "ofType" : {
+                    "kind" : "LIST",
+                    "name" : null,
+                    "description" : null,
+                    "ofType" : {
+                      "kind" : "NON_NULL",
+                      "name" : null,
+                      "description" : null,
+                      "ofType" : {
+                        "kind" : "SCALAR",
+                        "name" : "Int",
+                        "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar."
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("fields query") {
+    val query = """
+      {
+        __type(name: "KindTest") {
+          name
+          fields {
+            name
+            type {
+              name
+              fields {
+                name
+                type {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "name" : "KindTest",
+            "fields" : [
+              {
+                "name" : "scalar",
+                "type" : {
+                  "name" : "Int",
+                  "fields" : null
+                }
+              },
+              {
+                "name" : "object",
+                "type" : {
+                  "name" : "User",
+                  "fields" : [
+                    {
+                      "name" : "id",
+                      "type" : {
+                        "name" : "String"
+                      }
+                    },
+                    {
+                      "name" : "name",
+                      "type" : {
+                        "name" : "String"
+                      }
+                    },
+                    {
+                      "name" : "birthday",
+                      "type" : {
+                        "name" : "Date"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "interface",
+                "type" : {
+                  "name" : "Profile",
+                  "fields" : [
+                    {
+                      "name" : "id",
+                      "type" : {
+                        "name" : "String"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "union",
+                "type" : {
+                  "name" : "Choice",
+                  "fields" : null
+                }
+              },
+              {
+                "name" : "enum",
+                "type" : {
+                  "name" : "Flags",
+                  "fields" : null
+                }
+              },
+              {
+                "name" : "list",
+                "type" : {
+                  "name" : null,
+                  "fields" : null
+                }
+              },
+              {
+                "name" : "nonnull",
+                "type" : {
+                  "name" : null,
+                  "fields" : null
+                }
+              },
+              {
+                "name" : "nonnulllistnonnull",
+                "type" : {
+                  "name" : null,
+                  "fields" : null
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("interfaces query") {
+    val query = """
+      {
+        __type(name: "KindTest") {
+          name
+          fields {
+            name
+            type {
+              interfaces {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "name" : "KindTest",
+            "fields" : [
+              {
+                "name" : "scalar",
+                "type" : {
+                  "interfaces" : null
+                }
+              },
+              {
+                "name" : "object",
+                "type" : {
+                  "interfaces" : [
+                    {
+                      "name" : "Profile"
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "interface",
+                "type" : {
+                  "interfaces" : null
+                }
+              },
+              {
+                "name" : "union",
+                "type" : {
+                  "interfaces" : null
+                }
+              },
+              {
+                "name" : "enum",
+                "type" : {
+                  "interfaces" : null
+                }
+              },
+              {
+                "name" : "list",
+                "type" : {
+                  "interfaces" : null
+                }
+              },
+              {
+                "name" : "nonnull",
+                "type" : {
+                  "interfaces" : null
+                }
+              },
+              {
+                "name" : "nonnulllistnonnull",
+                "type" : {
+                  "interfaces" : null
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("possibleTypes query") {
+    val query = """
+      {
+        __type(name: "KindTest") {
+          name
+          fields {
+            name
+            type {
+              possibleTypes {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "name" : "KindTest",
+            "fields" : [
+              {
+                "name" : "scalar",
+                "type" : {
+                  "possibleTypes" : null
+                }
+              },
+              {
+                "name" : "object",
+                "type" : {
+                  "possibleTypes" : null
+                }
+              },
+              {
+                "name" : "interface",
+                "type" : {
+                  "possibleTypes" : [
+                    {
+                      "name" : "User"
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "union",
+                "type" : {
+                  "possibleTypes" : [
+                    {
+                      "name" : "User"
+                    },
+                    {
+                      "name" : "Date"
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "enum",
+                "type" : {
+                  "possibleTypes" : null
+                }
+              },
+              {
+                "name" : "list",
+                "type" : {
+                  "possibleTypes" : null
+                }
+              },
+              {
+                "name" : "nonnull",
+                "type" : {
+                  "possibleTypes" : null
+                }
+              },
+              {
+                "name" : "nonnulllistnonnull",
+                "type" : {
+                  "possibleTypes" : null
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("enumValues query") {
+    val query = """
+      {
+        __type(name: "KindTest") {
+          name
+          fields {
+            name
+            type {
+              enumValues {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "name" : "KindTest",
+            "fields" : [
+              {
+                "name" : "scalar",
+                "type" : {
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "object",
+                "type" : {
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "interface",
+                "type" : {
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "union",
+                "type" : {
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "enum",
+                "type" : {
+                  "enumValues" : [
+                    {
+                      "name" : "A"
+                    },
+                    {
+                      "name" : "C"
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "list",
+                "type" : {
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "nonnull",
+                "type" : {
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "nonnulllistnonnull",
+                "type" : {
+                  "enumValues" : null
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("deprecation excluded") {
+    val query = """
+      {
+        __type(name: "DeprecationTest") {
+          fields {
+            name
+            type {
+              fields(includeDeprecated: false) {
+                name
+                isDeprecated
+                deprecationReason
+              }
+              enumValues(includeDeprecated: false) {
+                name
+                isDeprecated
+                deprecationReason
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "fields" : [
+              {
+                "name" : "user",
+                "type" : {
+                  "fields" : [
+                    {
+                      "name" : "id",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    },
+                    {
+                      "name" : "name",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    },
+                    {
+                      "name" : "birthday",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    }
+                  ],
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "flags",
+                "type" : {
+                  "fields" : null,
+                  "enumValues" : [
+                    {
+                      "name" : "A",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    },
+                    {
+                      "name" : "C",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("deprecation included") {
+    val query = """
+      {
+        __type(name: "DeprecationTest") {
+          fields {
+            name
+            type {
+              fields(includeDeprecated: true) {
+                name
+                isDeprecated
+                deprecationReason
+              }
+              enumValues(includeDeprecated: true) {
+                name
+                isDeprecated
+                deprecationReason
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "fields" : [
+              {
+                "name" : "user",
+                "type" : {
+                  "fields" : [
+                    {
+                      "name" : "id",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    },
+                    {
+                      "name" : "name",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    },
+                    {
+                      "name" : "age",
+                      "isDeprecated" : true,
+                      "deprecationReason" : "Use birthday instead"
+                    },
+                    {
+                      "name" : "birthday",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    }
+                  ],
+                  "enumValues" : null
+                }
+              },
+              {
+                "name" : "flags",
+                "type" : {
+                  "fields" : null,
+                  "enumValues" : [
+                    {
+                      "name" : "A",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    },
+                    {
+                      "name" : "B",
+                      "isDeprecated" : true,
+                      "deprecationReason" : "Deprecation test"
+                    },
+                    {
+                      "name" : "C",
+                      "isDeprecated" : false,
+                      "deprecationReason" : null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("simple schema query") {
+    val query = """
+      {
+        __schema {
+          queryType { name }
+          mutationType { name }
+          subscriptionType { name }
+          types { name }
+          directives { name }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__schema" : {
+            "queryType" : {
+              "name" : "Query"
+            },
+            "mutationType" : null,
+            "subscriptionType" : null,
+            "types" : [
+              {
+                "name" : "Query"
+              },
+              {
+                "name" : "User"
+              },
+              {
+                "name" : "Profile"
+              },
+              {
+                "name" : "Date"
+              },
+              {
+                "name" : "Choice"
+              },
+              {
+                "name" : "Flags"
+              },
+              {
+                "name" : "KindTest"
+              },
+              {
+                "name" : "DeprecationTest"
+              }
+            ],
+            "directives" : [
+            ]
+          }
+        }
+      }
+    """
+
+    val res0 = TestMapping.compileAndRun(query)
+    val res = stripStandardTypes(res0)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("standard introspection query") {
+    val query = """
+      |query IntrospectionQuery {
+      |  __schema {
+      |    queryType { name }
+      |    mutationType { name }
+      |    subscriptionType { name }
+      |    types {
+      |      ...FullType
+      |    }
+      |    directives {
+      |      name
+      |      description
+      |      locations
+      |      args {
+      |        ...InputValue
+      |      }
+      |    }
+      |  }
+      |}
+      |
+      |fragment FullType on __Type {
+      |  kind
+      |  name
+      |  description
+      |  fields(includeDeprecated: true) {
+      |    name
+      |    description
+      |    args {
+      |      ...InputValue
+      |    }
+      |    type {
+      |      ...TypeRef
+      |    }
+      |    isDeprecated
+      |    deprecationReason
+      |  }
+      |  inputFields {
+      |    ...InputValue
+      |  }
+      |  interfaces {
+      |    ...TypeRef
+      |  }
+      |  enumValues(includeDeprecated: true) {
+      |    name
+      |    description
+      |    isDeprecated
+      |    deprecationReason
+      |  }
+      |  possibleTypes {
+      |    ...TypeRef
+      |  }
+      |}
+      |
+      |fragment InputValue on __InputValue {
+      |  name
+      |  description
+      |  type { ...TypeRef }
+      |  defaultValue
+      |}
+      |
+      |fragment TypeRef on __Type {
+      |  kind
+      |  name
+      |  ofType {
+      |    kind
+      |    name
+      |    ofType {
+      |      kind
+      |      name
+      |      ofType {
+      |        kind
+      |        name
+      |        ofType {
+      |          kind
+      |          name
+      |          ofType {
+      |            kind
+      |            name
+      |            ofType {
+      |              kind
+      |              name
+      |              ofType {
+      |                kind
+      |                name
+      |              }
+      |            }
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}
+    """.stripMargin.trim
+
+    val expected = json"""
+      {
+        "data" : {
+          "__schema" : {
+            "queryType" : {
+              "name" : "Query"
+            },
+            "mutationType" : {
+              "name" : "Mutation"
+            },
+            "subscriptionType" : {
+              "name" : "Subscription"
+            },
+            "types" : [
+              {
+                "kind" : "OBJECT",
+                "name" : "Query",
+                "description" : null,
+                "fields" : [
+                  {
+                    "name" : "users",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "NON_NULL",
+                      "name" : null,
+                      "ofType" : {
+                        "kind" : "LIST",
+                        "name" : null,
+                        "ofType" : {
+                          "kind" : "NON_NULL",
+                          "name" : null,
+                          "ofType" : {
+                            "kind" : "OBJECT",
+                            "name" : "User",
+                            "ofType" : null
+                          }
+                        }
+                      }
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  },
+                  {
+                    "name" : "profiles",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "NON_NULL",
+                      "name" : null,
+                      "ofType" : {
+                        "kind" : "LIST",
+                        "name" : null,
+                        "ofType" : {
+                          "kind" : "NON_NULL",
+                          "name" : null,
+                          "ofType" : {
+                            "kind" : "INTERFACE",
+                            "name" : "Profile",
+                            "ofType" : null
+                          }
+                        }
+                      }
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  }
+                ],
+                "inputFields" : null,
+                "interfaces" : [
+                ],
+                "enumValues" : null,
+                "possibleTypes" : null
+              },
+              {
+                "kind" : "OBJECT",
+                "name" : "Subscription",
+                "description" : null,
+                "fields" : [
+                  {
+                    "name" : "dummy",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "NON_NULL",
+                      "name" : null,
+                      "ofType" : {
+                        "kind" : "SCALAR",
+                        "name" : "Int",
+                        "ofType" : null
+                      }
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  }
+                ],
+                "inputFields" : null,
+                "interfaces" : [
+                ],
+                "enumValues" : null,
+                "possibleTypes" : null
+              },
+              {
+                "kind" : "OBJECT",
+                "name" : "Mutation",
+                "description" : null,
+                "fields" : [
+                  {
+                    "name" : "dummy",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "NON_NULL",
+                      "name" : null,
+                      "ofType" : {
+                        "kind" : "SCALAR",
+                        "name" : "Int",
+                        "ofType" : null
+                      }
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  }
+                ],
+                "inputFields" : null,
+                "interfaces" : [
+                ],
+                "enumValues" : null,
+                "possibleTypes" : null
+              },
+              {
+                "kind" : "INTERFACE",
+                "name" : "Profile",
+                "description" : "Profile interface type",
+                "fields" : [
+                  {
+                    "name" : "id",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "SCALAR",
+                      "name" : "String",
+                      "ofType" : null
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  }
+                ],
+                "inputFields" : null,
+                "interfaces" : null,
+                "enumValues" : null,
+                "possibleTypes" : [
+                  {
+                    "kind" : "OBJECT",
+                    "name" : "User",
+                    "ofType" : null
+                  }
+                ]
+              },
+              {
+                "kind" : "OBJECT",
+                "name" : "User",
+                "description" : "User object type",
+                "fields" : [
+                  {
+                    "name" : "id",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "SCALAR",
+                      "name" : "String",
+                      "ofType" : null
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  },
+                  {
+                    "name" : "name",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "SCALAR",
+                      "name" : "String",
+                      "ofType" : null
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  },
+                  {
+                    "name" : "age",
+                    "description" : null,
+                    "args" : [
+                    ],
+                    "type" : {
+                      "kind" : "SCALAR",
+                      "name" : "Int",
+                      "ofType" : null
+                    },
+                    "isDeprecated" : false,
+                    "deprecationReason" : null
+                  }
+                ],
+                "inputFields" : null,
+                "interfaces" : [
+                  {
+                    "kind" : "INTERFACE",
+                    "name" : "Profile",
+                    "ofType" : null
+                  }
+                ],
+                "enumValues" : null,
+                "possibleTypes" : null
+              }
+            ],
+            "directives" : [
+            ]
+          }
+        }
+      }
+    """
+
+    val res0 = SmallMapping.compileAndRun(query)
+    val res = stripStandardTypes(res0)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("typename query") {
+    val query = """
+      {
+        users {
+          __typename
+          renamed: __typename
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "users" : [
+            {
+              "__typename" : "User",
+              "renamed" : "User",
+              "name" : "Luke Skywalker"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = SmallMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("typename query with narrowing") {
+    val query = """
+      {
+        profiles {
+          __typename
+          id
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "profiles" : [
+            {
+              "__typename" : "User",
+              "id" : "1000"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = SmallMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("mixed query") {
+    val query = """
+      {
+        users {
+          name
+        }
+        __type(name: "User") {
+          name
+          fields {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "users" : [
+            {
+              "name" : "Luke Skywalker"
+            }
+          ],
+          "__type" : {
+            "name": "User",
+            "fields" : [
+              {
+                "name" : "id"
+              },
+              {
+                "name" : "name"
+              },
+              {
+                "name" : "age"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = SmallMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("introspection disabled") {
+    val query = """
+      {
+        __type(name: "User") {
+          name
+          fields {
+            name
+            type {
+              name
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unknown field '__type' in 'Query'"
+          }
+        ]
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query, introspectionLevel = Disabled)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("introspection disabled typename allowed") {
+    val query = """
+      {
+        users {
+          __typename
+          renamed: __typename
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "users" : [
+            {
+              "__typename" : "User",
+              "renamed" : "User",
+              "name" : "Luke Skywalker"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = SmallMapping.compileAndRun(query, introspectionLevel = TypenameOnly)
+    //println(res)
+
+    assert(res == expected)
+  }
+}
+
+object TestMapping extends Mapping[Id] {
+  val schema =
+    schema"""
+      type Query {
+        users: [User!]!
+      }
+
+      "User object type"
+      type User implements Profile {
+        id: String
+        name: String
+        age: Int @deprecated(reason: "Use birthday instead")
+        birthday: Date
+      }
+
+      "Profile interface type"
+      interface Profile {
+        id: String
+      }
+
+      "Date object type"
+      type Date {
+        day: Int
+        month: Int
+        year: Int
+      }
+
+      "Choice union type"
+      union Choice = User | Date
+
+      "Flags enum type"
+      enum Flags {
+        A
+        B @deprecated(reason: "Deprecation test")
+        C
+      }
+
+      type KindTest {
+        "Scalar field"
+        scalar: Int
+        "Object field"
+        object: User
+        "Interface field"
+        interface: Profile
+        "Union field"
+        union: Choice
+        "Enum field"
+        enum: Flags
+        "List field"
+        list: [Int]
+        "Nonnull field"
+        nonnull: Int!
+        "Nonnull list of nonnull field"
+        nonnulllistnonnull: [Int!]!
+      }
+
+      type DeprecationTest {
+        user: User
+        flags: Flags
+      }
+    """
+
+  val typeMappings = Nil
+}
+
+object SmallData {
+  trait Profile {
+    def id: Option[String]
+  }
+  case class User(id: Option[String], name: Option[String], age: Option[Int]) extends Profile
+  val users = List(
+    User(Some("1000"), Some("Luke Skywalker"), Some(30))
+  )
+}
+
+object SmallMapping extends ValueMapping[Id] {
+  import SmallData._
+
+  val schema =
+    schema"""
+      type Query {
+        users: [User!]!
+        profiles: [Profile!]!
+      }
+      type Subscription {
+        dummy: Int!
+      }
+      type Mutation {
+        dummy: Int!
+      }
+      "Profile interface type"
+      interface Profile {
+        id: String
+      }
+      "User object type"
+      type User implements Profile {
+        id: String
+        name: String
+        age: Int
+      }
+    """
+
+  val QueryType = schema.queryType
+  val UserType = schema.ref("User")
+  val ProfileType = schema.ref("Profile")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueRoot("users", users),
+            ValueRoot("profiles", users)
+          )
+      ),
+      ValueObjectMapping[User](
+        tpe = UserType,
+        fieldMappings =
+          List(
+            ValueField("name", _.name),
+            ValueField("age", _.age)
+          )
+      ),
+      ValueObjectMapping[Profile](
+        tpe = ProfileType,
+        fieldMappings =
+          List(
+            ValueField("id", _.id)
+          )
+      )
+  )
+}

--- a/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
@@ -1,1504 +1,1504 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package introspection
-
-import cats.Id
-import cats.tests.CatsSuite
-import io.circe.{ ACursor, Json }
-
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
-import QueryCompiler.IntrospectionLevel
-import IntrospectionLevel._
-
-final class IntrospectionSuite extends CatsSuite {
-  def standardTypeName(name: String): Boolean = name match {
-    case "Int" | "Float" | "Boolean" | "String" | "ID" => true
-    case _ => name.startsWith("__")
-  }
-
-  implicit class ACursorOps(self: ACursor) {
-    def filterArray(f: Json => Boolean): ACursor = {
-      def go(ac: ACursor, i: Int = 0): ACursor = {
-        val acʹ = ac.downN(i)
-        acʹ.focus match {
-          case None    => ac
-          case Some(j) => if (f(j)) go(ac, i + 1) else go(acʹ.delete, i)
-        }
-      }
-      go(self)
-    }
-  }
-
-  def stripStandardTypes(result: Json): Json =
-    result
-      .hcursor
-      .downField("data")
-      .downField("__schema")
-      .downField("types")
-      .filterArray(_.hcursor.downField("name").as[String].exists(!standardTypeName(_)))
-      .top // .root doesn't work in 0.13
-      .getOrElse(sys.error("stripStandardTypes failed"))
-
-  test("simple type query") {
-    val query = """
-      {
-        __type(name: "User") {
-          name
-          fields {
-            name
-            type {
-              name
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type": {
-            "name": "User",
-            "fields": [
-              {
-                "name": "id",
-                "type": { "name": "String" }
-              },
-              {
-                "name": "name",
-                "type": { "name": "String" }
-              },
-              {
-                "name": "birthday",
-                "type": { "name": "Date" }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("kind/name/description/ofType query") {
-    val query = """
-      {
-        __type(name: "KindTest") {
-          name
-          description
-          fields {
-            name
-            description
-            type {
-              kind
-              name
-              description
-              ofType {
-                kind
-                name
-                description
-                ofType {
-                  kind
-                  name
-                  description
-                  ofType {
-                    kind
-                    name
-                    description
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "name" : "KindTest",
-            "description" : null,
-            "fields" : [
-              {
-                "name" : "scalar",
-                "description" : "Scalar field",
-                "type" : {
-                  "kind" : "SCALAR",
-                  "name" : "Int",
-                  "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
-                  "ofType" : null
-                }
-              },
-              {
-                "name" : "object",
-                "description" : "Object field",
-                "type" : {
-                  "kind" : "OBJECT",
-                  "name" : "User",
-                  "description" : "User object type",
-                  "ofType" : null
-                }
-              },
-              {
-                "name" : "interface",
-                "description" : "Interface field",
-                "type" : {
-                  "kind" : "INTERFACE",
-                  "name" : "Profile",
-                  "description" : "Profile interface type",
-                  "ofType" : null
-                }
-              },
-              {
-                "name" : "union",
-                "description" : "Union field",
-                "type" : {
-                  "kind" : "UNION",
-                  "name" : "Choice",
-                  "description" : "Choice union type",
-                  "ofType" : null
-                }
-              },
-              {
-                "name" : "enum",
-                "description" : "Enum field",
-                "type" : {
-                  "kind" : "ENUM",
-                  "name" : "Flags",
-                  "description" : "Flags enum type",
-                  "ofType" : null
-                }
-              },
-              {
-                "name" : "list",
-                "description" : "List field",
-                "type" : {
-                  "kind" : "LIST",
-                  "name" : null,
-                  "description" : null,
-                  "ofType" : {
-                    "kind" : "SCALAR",
-                    "name" : "Int",
-                    "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
-                    "ofType" : null
-                  }
-                }
-              },
-              {
-                "name" : "nonnull",
-                "description" : "Nonnull field",
-                "type" : {
-                  "kind" : "NON_NULL",
-                  "name" : null,
-                  "description" : null,
-                  "ofType" : {
-                    "kind" : "SCALAR",
-                    "name" : "Int",
-                    "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
-                    "ofType" : null
-                  }
-                }
-              },
-              {
-                "name" : "nonnulllistnonnull",
-                "description" : "Nonnull list of nonnull field",
-                "type" : {
-                  "kind" : "NON_NULL",
-                  "name" : null,
-                  "description" : null,
-                  "ofType" : {
-                    "kind" : "LIST",
-                    "name" : null,
-                    "description" : null,
-                    "ofType" : {
-                      "kind" : "NON_NULL",
-                      "name" : null,
-                      "description" : null,
-                      "ofType" : {
-                        "kind" : "SCALAR",
-                        "name" : "Int",
-                        "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar."
-                      }
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("fields query") {
-    val query = """
-      {
-        __type(name: "KindTest") {
-          name
-          fields {
-            name
-            type {
-              name
-              fields {
-                name
-                type {
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "name" : "KindTest",
-            "fields" : [
-              {
-                "name" : "scalar",
-                "type" : {
-                  "name" : "Int",
-                  "fields" : null
-                }
-              },
-              {
-                "name" : "object",
-                "type" : {
-                  "name" : "User",
-                  "fields" : [
-                    {
-                      "name" : "id",
-                      "type" : {
-                        "name" : "String"
-                      }
-                    },
-                    {
-                      "name" : "name",
-                      "type" : {
-                        "name" : "String"
-                      }
-                    },
-                    {
-                      "name" : "birthday",
-                      "type" : {
-                        "name" : "Date"
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "name" : "interface",
-                "type" : {
-                  "name" : "Profile",
-                  "fields" : [
-                    {
-                      "name" : "id",
-                      "type" : {
-                        "name" : "String"
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "name" : "union",
-                "type" : {
-                  "name" : "Choice",
-                  "fields" : null
-                }
-              },
-              {
-                "name" : "enum",
-                "type" : {
-                  "name" : "Flags",
-                  "fields" : null
-                }
-              },
-              {
-                "name" : "list",
-                "type" : {
-                  "name" : null,
-                  "fields" : null
-                }
-              },
-              {
-                "name" : "nonnull",
-                "type" : {
-                  "name" : null,
-                  "fields" : null
-                }
-              },
-              {
-                "name" : "nonnulllistnonnull",
-                "type" : {
-                  "name" : null,
-                  "fields" : null
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("interfaces query") {
-    val query = """
-      {
-        __type(name: "KindTest") {
-          name
-          fields {
-            name
-            type {
-              interfaces {
-                name
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "name" : "KindTest",
-            "fields" : [
-              {
-                "name" : "scalar",
-                "type" : {
-                  "interfaces" : null
-                }
-              },
-              {
-                "name" : "object",
-                "type" : {
-                  "interfaces" : [
-                    {
-                      "name" : "Profile"
-                    }
-                  ]
-                }
-              },
-              {
-                "name" : "interface",
-                "type" : {
-                  "interfaces" : null
-                }
-              },
-              {
-                "name" : "union",
-                "type" : {
-                  "interfaces" : null
-                }
-              },
-              {
-                "name" : "enum",
-                "type" : {
-                  "interfaces" : null
-                }
-              },
-              {
-                "name" : "list",
-                "type" : {
-                  "interfaces" : null
-                }
-              },
-              {
-                "name" : "nonnull",
-                "type" : {
-                  "interfaces" : null
-                }
-              },
-              {
-                "name" : "nonnulllistnonnull",
-                "type" : {
-                  "interfaces" : null
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("possibleTypes query") {
-    val query = """
-      {
-        __type(name: "KindTest") {
-          name
-          fields {
-            name
-            type {
-              possibleTypes {
-                name
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "name" : "KindTest",
-            "fields" : [
-              {
-                "name" : "scalar",
-                "type" : {
-                  "possibleTypes" : null
-                }
-              },
-              {
-                "name" : "object",
-                "type" : {
-                  "possibleTypes" : null
-                }
-              },
-              {
-                "name" : "interface",
-                "type" : {
-                  "possibleTypes" : [
-                    {
-                      "name" : "User"
-                    }
-                  ]
-                }
-              },
-              {
-                "name" : "union",
-                "type" : {
-                  "possibleTypes" : [
-                    {
-                      "name" : "User"
-                    },
-                    {
-                      "name" : "Date"
-                    }
-                  ]
-                }
-              },
-              {
-                "name" : "enum",
-                "type" : {
-                  "possibleTypes" : null
-                }
-              },
-              {
-                "name" : "list",
-                "type" : {
-                  "possibleTypes" : null
-                }
-              },
-              {
-                "name" : "nonnull",
-                "type" : {
-                  "possibleTypes" : null
-                }
-              },
-              {
-                "name" : "nonnulllistnonnull",
-                "type" : {
-                  "possibleTypes" : null
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("enumValues query") {
-    val query = """
-      {
-        __type(name: "KindTest") {
-          name
-          fields {
-            name
-            type {
-              enumValues {
-                name
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "name" : "KindTest",
-            "fields" : [
-              {
-                "name" : "scalar",
-                "type" : {
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "object",
-                "type" : {
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "interface",
-                "type" : {
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "union",
-                "type" : {
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "enum",
-                "type" : {
-                  "enumValues" : [
-                    {
-                      "name" : "A"
-                    },
-                    {
-                      "name" : "C"
-                    }
-                  ]
-                }
-              },
-              {
-                "name" : "list",
-                "type" : {
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "nonnull",
-                "type" : {
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "nonnulllistnonnull",
-                "type" : {
-                  "enumValues" : null
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("deprecation excluded") {
-    val query = """
-      {
-        __type(name: "DeprecationTest") {
-          fields {
-            name
-            type {
-              fields(includeDeprecated: false) {
-                name
-                isDeprecated
-                deprecationReason
-              }
-              enumValues(includeDeprecated: false) {
-                name
-                isDeprecated
-                deprecationReason
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "fields" : [
-              {
-                "name" : "user",
-                "type" : {
-                  "fields" : [
-                    {
-                      "name" : "id",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    },
-                    {
-                      "name" : "name",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    },
-                    {
-                      "name" : "birthday",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    }
-                  ],
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "flags",
-                "type" : {
-                  "fields" : null,
-                  "enumValues" : [
-                    {
-                      "name" : "A",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    },
-                    {
-                      "name" : "C",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("deprecation included") {
-    val query = """
-      {
-        __type(name: "DeprecationTest") {
-          fields {
-            name
-            type {
-              fields(includeDeprecated: true) {
-                name
-                isDeprecated
-                deprecationReason
-              }
-              enumValues(includeDeprecated: true) {
-                name
-                isDeprecated
-                deprecationReason
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__type" : {
-            "fields" : [
-              {
-                "name" : "user",
-                "type" : {
-                  "fields" : [
-                    {
-                      "name" : "id",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    },
-                    {
-                      "name" : "name",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    },
-                    {
-                      "name" : "age",
-                      "isDeprecated" : true,
-                      "deprecationReason" : "Use birthday instead"
-                    },
-                    {
-                      "name" : "birthday",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    }
-                  ],
-                  "enumValues" : null
-                }
-              },
-              {
-                "name" : "flags",
-                "type" : {
-                  "fields" : null,
-                  "enumValues" : [
-                    {
-                      "name" : "A",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    },
-                    {
-                      "name" : "B",
-                      "isDeprecated" : true,
-                      "deprecationReason" : "Deprecation test"
-                    },
-                    {
-                      "name" : "C",
-                      "isDeprecated" : false,
-                      "deprecationReason" : null
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("simple schema query") {
-    val query = """
-      {
-        __schema {
-          queryType { name }
-          mutationType { name }
-          subscriptionType { name }
-          types { name }
-          directives { name }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "__schema" : {
-            "queryType" : {
-              "name" : "Query"
-            },
-            "mutationType" : null,
-            "subscriptionType" : null,
-            "types" : [
-              {
-                "name" : "Query"
-              },
-              {
-                "name" : "User"
-              },
-              {
-                "name" : "Profile"
-              },
-              {
-                "name" : "Date"
-              },
-              {
-                "name" : "Choice"
-              },
-              {
-                "name" : "Flags"
-              },
-              {
-                "name" : "KindTest"
-              },
-              {
-                "name" : "DeprecationTest"
-              }
-            ],
-            "directives" : [
-            ]
-          }
-        }
-      }
-    """
-
-    val res0 = TestMapping.compileAndRun(query)
-    val res = stripStandardTypes(res0)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("standard introspection query") {
-    val query = """
-      |query IntrospectionQuery {
-      |  __schema {
-      |    queryType { name }
-      |    mutationType { name }
-      |    subscriptionType { name }
-      |    types {
-      |      ...FullType
-      |    }
-      |    directives {
-      |      name
-      |      description
-      |      locations
-      |      args {
-      |        ...InputValue
-      |      }
-      |    }
-      |  }
-      |}
-      |
-      |fragment FullType on __Type {
-      |  kind
-      |  name
-      |  description
-      |  fields(includeDeprecated: true) {
-      |    name
-      |    description
-      |    args {
-      |      ...InputValue
-      |    }
-      |    type {
-      |      ...TypeRef
-      |    }
-      |    isDeprecated
-      |    deprecationReason
-      |  }
-      |  inputFields {
-      |    ...InputValue
-      |  }
-      |  interfaces {
-      |    ...TypeRef
-      |  }
-      |  enumValues(includeDeprecated: true) {
-      |    name
-      |    description
-      |    isDeprecated
-      |    deprecationReason
-      |  }
-      |  possibleTypes {
-      |    ...TypeRef
-      |  }
-      |}
-      |
-      |fragment InputValue on __InputValue {
-      |  name
-      |  description
-      |  type { ...TypeRef }
-      |  defaultValue
-      |}
-      |
-      |fragment TypeRef on __Type {
-      |  kind
-      |  name
-      |  ofType {
-      |    kind
-      |    name
-      |    ofType {
-      |      kind
-      |      name
-      |      ofType {
-      |        kind
-      |        name
-      |        ofType {
-      |          kind
-      |          name
-      |          ofType {
-      |            kind
-      |            name
-      |            ofType {
-      |              kind
-      |              name
-      |              ofType {
-      |                kind
-      |                name
-      |              }
-      |            }
-      |          }
-      |        }
-      |      }
-      |    }
-      |  }
-      |}
-    """.stripMargin.trim
-
-    val expected = json"""
-      {
-        "data" : {
-          "__schema" : {
-            "queryType" : {
-              "name" : "Query"
-            },
-            "mutationType" : {
-              "name" : "Mutation"
-            },
-            "subscriptionType" : {
-              "name" : "Subscription"
-            },
-            "types" : [
-              {
-                "kind" : "OBJECT",
-                "name" : "Query",
-                "description" : null,
-                "fields" : [
-                  {
-                    "name" : "users",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "NON_NULL",
-                      "name" : null,
-                      "ofType" : {
-                        "kind" : "LIST",
-                        "name" : null,
-                        "ofType" : {
-                          "kind" : "NON_NULL",
-                          "name" : null,
-                          "ofType" : {
-                            "kind" : "OBJECT",
-                            "name" : "User",
-                            "ofType" : null
-                          }
-                        }
-                      }
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  },
-                  {
-                    "name" : "profiles",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "NON_NULL",
-                      "name" : null,
-                      "ofType" : {
-                        "kind" : "LIST",
-                        "name" : null,
-                        "ofType" : {
-                          "kind" : "NON_NULL",
-                          "name" : null,
-                          "ofType" : {
-                            "kind" : "INTERFACE",
-                            "name" : "Profile",
-                            "ofType" : null
-                          }
-                        }
-                      }
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  }
-                ],
-                "inputFields" : null,
-                "interfaces" : [
-                ],
-                "enumValues" : null,
-                "possibleTypes" : null
-              },
-              {
-                "kind" : "OBJECT",
-                "name" : "Subscription",
-                "description" : null,
-                "fields" : [
-                  {
-                    "name" : "dummy",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "NON_NULL",
-                      "name" : null,
-                      "ofType" : {
-                        "kind" : "SCALAR",
-                        "name" : "Int",
-                        "ofType" : null
-                      }
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  }
-                ],
-                "inputFields" : null,
-                "interfaces" : [
-                ],
-                "enumValues" : null,
-                "possibleTypes" : null
-              },
-              {
-                "kind" : "OBJECT",
-                "name" : "Mutation",
-                "description" : null,
-                "fields" : [
-                  {
-                    "name" : "dummy",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "NON_NULL",
-                      "name" : null,
-                      "ofType" : {
-                        "kind" : "SCALAR",
-                        "name" : "Int",
-                        "ofType" : null
-                      }
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  }
-                ],
-                "inputFields" : null,
-                "interfaces" : [
-                ],
-                "enumValues" : null,
-                "possibleTypes" : null
-              },
-              {
-                "kind" : "INTERFACE",
-                "name" : "Profile",
-                "description" : "Profile interface type",
-                "fields" : [
-                  {
-                    "name" : "id",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "SCALAR",
-                      "name" : "String",
-                      "ofType" : null
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  }
-                ],
-                "inputFields" : null,
-                "interfaces" : null,
-                "enumValues" : null,
-                "possibleTypes" : [
-                  {
-                    "kind" : "OBJECT",
-                    "name" : "User",
-                    "ofType" : null
-                  }
-                ]
-              },
-              {
-                "kind" : "OBJECT",
-                "name" : "User",
-                "description" : "User object type",
-                "fields" : [
-                  {
-                    "name" : "id",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "SCALAR",
-                      "name" : "String",
-                      "ofType" : null
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  },
-                  {
-                    "name" : "name",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "SCALAR",
-                      "name" : "String",
-                      "ofType" : null
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  },
-                  {
-                    "name" : "age",
-                    "description" : null,
-                    "args" : [
-                    ],
-                    "type" : {
-                      "kind" : "SCALAR",
-                      "name" : "Int",
-                      "ofType" : null
-                    },
-                    "isDeprecated" : false,
-                    "deprecationReason" : null
-                  }
-                ],
-                "inputFields" : null,
-                "interfaces" : [
-                  {
-                    "kind" : "INTERFACE",
-                    "name" : "Profile",
-                    "ofType" : null
-                  }
-                ],
-                "enumValues" : null,
-                "possibleTypes" : null
-              }
-            ],
-            "directives" : [
-            ]
-          }
-        }
-      }
-    """
-
-    val res0 = SmallMapping.compileAndRun(query)
-    val res = stripStandardTypes(res0)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("typename query") {
-    val query = """
-      {
-        users {
-          __typename
-          renamed: __typename
-          name
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "users" : [
-            {
-              "__typename" : "User",
-              "renamed" : "User",
-              "name" : "Luke Skywalker"
-            }
-          ]
-        }
-      }
-    """
-
-    val res = SmallMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("typename query with narrowing") {
-    val query = """
-      {
-        profiles {
-          __typename
-          id
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "profiles" : [
-            {
-              "__typename" : "User",
-              "id" : "1000"
-            }
-          ]
-        }
-      }
-    """
-
-    val res = SmallMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("mixed query") {
-    val query = """
-      {
-        users {
-          name
-        }
-        __type(name: "User") {
-          name
-          fields {
-            name
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "users" : [
-            {
-              "name" : "Luke Skywalker"
-            }
-          ],
-          "__type" : {
-            "name": "User",
-            "fields" : [
-              {
-                "name" : "id"
-              },
-              {
-                "name" : "name"
-              },
-              {
-                "name" : "age"
-              }
-            ]
-          }
-        }
-      }
-    """
-
-    val res = SmallMapping.compileAndRun(query)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("introspection disabled") {
-    val query = """
-      {
-        __type(name: "User") {
-          name
-          fields {
-            name
-            type {
-              name
-            }
-          }
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "errors" : [
-          {
-            "message" : "Unknown field '__type' in 'Query'"
-          }
-        ]
-      }
-    """
-
-    val res = TestMapping.compileAndRun(query, introspectionLevel = Disabled)
-    //println(res)
-
-    assert(res == expected)
-  }
-
-  test("introspection disabled typename allowed") {
-    val query = """
-      {
-        users {
-          __typename
-          renamed: __typename
-          name
-        }
-      }
-    """
-
-    val expected = json"""
-      {
-        "data" : {
-          "users" : [
-            {
-              "__typename" : "User",
-              "renamed" : "User",
-              "name" : "Luke Skywalker"
-            }
-          ]
-        }
-      }
-    """
-
-    val res = SmallMapping.compileAndRun(query, introspectionLevel = TypenameOnly)
-    //println(res)
-
-    assert(res == expected)
-  }
-}
-
-object TestMapping extends Mapping[Id] {
-  val schema =
-    schema"""
-      type Query {
-        users: [User!]!
-      }
-
-      "User object type"
-      type User implements Profile {
-        id: String
-        name: String
-        age: Int @deprecated(reason: "Use birthday instead")
-        birthday: Date
-      }
-
-      "Profile interface type"
-      interface Profile {
-        id: String
-      }
-
-      "Date object type"
-      type Date {
-        day: Int
-        month: Int
-        year: Int
-      }
-
-      "Choice union type"
-      union Choice = User | Date
-
-      "Flags enum type"
-      enum Flags {
-        A
-        B @deprecated(reason: "Deprecation test")
-        C
-      }
-
-      type KindTest {
-        "Scalar field"
-        scalar: Int
-        "Object field"
-        object: User
-        "Interface field"
-        interface: Profile
-        "Union field"
-        union: Choice
-        "Enum field"
-        enum: Flags
-        "List field"
-        list: [Int]
-        "Nonnull field"
-        nonnull: Int!
-        "Nonnull list of nonnull field"
-        nonnulllistnonnull: [Int!]!
-      }
-
-      type DeprecationTest {
-        user: User
-        flags: Flags
-      }
-    """
-
-  val typeMappings = Nil
-}
-
-object SmallData {
-  trait Profile {
-    def id: Option[String]
-  }
-  case class User(id: Option[String], name: Option[String], age: Option[Int]) extends Profile
-  val users = List(
-    User(Some("1000"), Some("Luke Skywalker"), Some(30))
-  )
-}
-
-object SmallMapping extends ValueMapping[Id] {
-  import SmallData._
-
-  val schema =
-    schema"""
-      type Query {
-        users: [User!]!
-        profiles: [Profile!]!
-      }
-      type Subscription {
-        dummy: Int!
-      }
-      type Mutation {
-        dummy: Int!
-      }
-      "Profile interface type"
-      interface Profile {
-        id: String
-      }
-      "User object type"
-      type User implements Profile {
-        id: String
-        name: String
-        age: Int
-      }
-    """
-
-  val QueryType = schema.queryType
-  val UserType = schema.ref("User")
-  val ProfileType = schema.ref("Profile")
-
-  val typeMappings =
-    List(
-      ObjectMapping(
-        tpe = QueryType,
-        fieldMappings =
-          List(
-            ValueRoot("users", users),
-            ValueRoot("profiles", users)
-          )
-      ),
-      ValueObjectMapping[User](
-        tpe = UserType,
-        fieldMappings =
-          List(
-            ValueField("name", _.name),
-            ValueField("age", _.age)
-          )
-      ),
-      ValueObjectMapping[Profile](
-        tpe = ProfileType,
-        fieldMappings =
-          List(
-            ValueField("id", _.id)
-          )
-      )
-  )
-}
+// package introspection
+
+// import cats.Id
+// import cats.tests.CatsSuite
+// import io.circe.{ ACursor, Json }
+
+// import edu.gemini.grackle._
+// import edu.gemini.grackle.syntax._
+// import QueryCompiler.IntrospectionLevel
+// import IntrospectionLevel._
+
+// final class IntrospectionSuite extends CatsSuite {
+//   def standardTypeName(name: String): Boolean = name match {
+//     case "Int" | "Float" | "Boolean" | "String" | "ID" => true
+//     case _ => name.startsWith("__")
+//   }
+
+//   implicit class ACursorOps(self: ACursor) {
+//     def filterArray(f: Json => Boolean): ACursor = {
+//       def go(ac: ACursor, i: Int = 0): ACursor = {
+//         val acʹ = ac.downN(i)
+//         acʹ.focus match {
+//           case None    => ac
+//           case Some(j) => if (f(j)) go(ac, i + 1) else go(acʹ.delete, i)
+//         }
+//       }
+//       go(self)
+//     }
+//   }
+
+//   def stripStandardTypes(result: Json): Json =
+//     result
+//       .hcursor
+//       .downField("data")
+//       .downField("__schema")
+//       .downField("types")
+//       .filterArray(_.hcursor.downField("name").as[String].exists(!standardTypeName(_)))
+//       .top // .root doesn't work in 0.13
+//       .getOrElse(sys.error("stripStandardTypes failed"))
+
+//   test("simple type query") {
+//     val query = """
+//       {
+//         __type(name: "User") {
+//           name
+//           fields {
+//             name
+//             type {
+//               name
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type": {
+//             "name": "User",
+//             "fields": [
+//               {
+//                 "name": "id",
+//                 "type": { "name": "String" }
+//               },
+//               {
+//                 "name": "name",
+//                 "type": { "name": "String" }
+//               },
+//               {
+//                 "name": "birthday",
+//                 "type": { "name": "Date" }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("kind/name/description/ofType query") {
+//     val query = """
+//       {
+//         __type(name: "KindTest") {
+//           name
+//           description
+//           fields {
+//             name
+//             description
+//             type {
+//               kind
+//               name
+//               description
+//               ofType {
+//                 kind
+//                 name
+//                 description
+//                 ofType {
+//                   kind
+//                   name
+//                   description
+//                   ofType {
+//                     kind
+//                     name
+//                     description
+//                   }
+//                 }
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "name" : "KindTest",
+//             "description" : null,
+//             "fields" : [
+//               {
+//                 "name" : "scalar",
+//                 "description" : "Scalar field",
+//                 "type" : {
+//                   "kind" : "SCALAR",
+//                   "name" : "Int",
+//                   "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
+//                   "ofType" : null
+//                 }
+//               },
+//               {
+//                 "name" : "object",
+//                 "description" : "Object field",
+//                 "type" : {
+//                   "kind" : "OBJECT",
+//                   "name" : "User",
+//                   "description" : "User object type",
+//                   "ofType" : null
+//                 }
+//               },
+//               {
+//                 "name" : "interface",
+//                 "description" : "Interface field",
+//                 "type" : {
+//                   "kind" : "INTERFACE",
+//                   "name" : "Profile",
+//                   "description" : "Profile interface type",
+//                   "ofType" : null
+//                 }
+//               },
+//               {
+//                 "name" : "union",
+//                 "description" : "Union field",
+//                 "type" : {
+//                   "kind" : "UNION",
+//                   "name" : "Choice",
+//                   "description" : "Choice union type",
+//                   "ofType" : null
+//                 }
+//               },
+//               {
+//                 "name" : "enum",
+//                 "description" : "Enum field",
+//                 "type" : {
+//                   "kind" : "ENUM",
+//                   "name" : "Flags",
+//                   "description" : "Flags enum type",
+//                   "ofType" : null
+//                 }
+//               },
+//               {
+//                 "name" : "list",
+//                 "description" : "List field",
+//                 "type" : {
+//                   "kind" : "LIST",
+//                   "name" : null,
+//                   "description" : null,
+//                   "ofType" : {
+//                     "kind" : "SCALAR",
+//                     "name" : "Int",
+//                     "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
+//                     "ofType" : null
+//                   }
+//                 }
+//               },
+//               {
+//                 "name" : "nonnull",
+//                 "description" : "Nonnull field",
+//                 "type" : {
+//                   "kind" : "NON_NULL",
+//                   "name" : null,
+//                   "description" : null,
+//                   "ofType" : {
+//                     "kind" : "SCALAR",
+//                     "name" : "Int",
+//                     "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar.",
+//                     "ofType" : null
+//                   }
+//                 }
+//               },
+//               {
+//                 "name" : "nonnulllistnonnull",
+//                 "description" : "Nonnull list of nonnull field",
+//                 "type" : {
+//                   "kind" : "NON_NULL",
+//                   "name" : null,
+//                   "description" : null,
+//                   "ofType" : {
+//                     "kind" : "LIST",
+//                     "name" : null,
+//                     "description" : null,
+//                     "ofType" : {
+//                       "kind" : "NON_NULL",
+//                       "name" : null,
+//                       "description" : null,
+//                       "ofType" : {
+//                         "kind" : "SCALAR",
+//                         "name" : "Int",
+//                         "description" : "The Int scalar type represents a signed 32‐bit numeric non‐fractional value.\nResponse formats that support a 32‐bit integer or a number type should use that\ntype to represent this scalar."
+//                       }
+//                     }
+//                   }
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("fields query") {
+//     val query = """
+//       {
+//         __type(name: "KindTest") {
+//           name
+//           fields {
+//             name
+//             type {
+//               name
+//               fields {
+//                 name
+//                 type {
+//                   name
+//                 }
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "name" : "KindTest",
+//             "fields" : [
+//               {
+//                 "name" : "scalar",
+//                 "type" : {
+//                   "name" : "Int",
+//                   "fields" : null
+//                 }
+//               },
+//               {
+//                 "name" : "object",
+//                 "type" : {
+//                   "name" : "User",
+//                   "fields" : [
+//                     {
+//                       "name" : "id",
+//                       "type" : {
+//                         "name" : "String"
+//                       }
+//                     },
+//                     {
+//                       "name" : "name",
+//                       "type" : {
+//                         "name" : "String"
+//                       }
+//                     },
+//                     {
+//                       "name" : "birthday",
+//                       "type" : {
+//                         "name" : "Date"
+//                       }
+//                     }
+//                   ]
+//                 }
+//               },
+//               {
+//                 "name" : "interface",
+//                 "type" : {
+//                   "name" : "Profile",
+//                   "fields" : [
+//                     {
+//                       "name" : "id",
+//                       "type" : {
+//                         "name" : "String"
+//                       }
+//                     }
+//                   ]
+//                 }
+//               },
+//               {
+//                 "name" : "union",
+//                 "type" : {
+//                   "name" : "Choice",
+//                   "fields" : null
+//                 }
+//               },
+//               {
+//                 "name" : "enum",
+//                 "type" : {
+//                   "name" : "Flags",
+//                   "fields" : null
+//                 }
+//               },
+//               {
+//                 "name" : "list",
+//                 "type" : {
+//                   "name" : null,
+//                   "fields" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnull",
+//                 "type" : {
+//                   "name" : null,
+//                   "fields" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnulllistnonnull",
+//                 "type" : {
+//                   "name" : null,
+//                   "fields" : null
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("interfaces query") {
+//     val query = """
+//       {
+//         __type(name: "KindTest") {
+//           name
+//           fields {
+//             name
+//             type {
+//               interfaces {
+//                 name
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "name" : "KindTest",
+//             "fields" : [
+//               {
+//                 "name" : "scalar",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               },
+//               {
+//                 "name" : "object",
+//                 "type" : {
+//                   "interfaces" : [
+//                     {
+//                       "name" : "Profile"
+//                     }
+//                   ]
+//                 }
+//               },
+//               {
+//                 "name" : "interface",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               },
+//               {
+//                 "name" : "union",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               },
+//               {
+//                 "name" : "enum",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               },
+//               {
+//                 "name" : "list",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnull",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnulllistnonnull",
+//                 "type" : {
+//                   "interfaces" : null
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("possibleTypes query") {
+//     val query = """
+//       {
+//         __type(name: "KindTest") {
+//           name
+//           fields {
+//             name
+//             type {
+//               possibleTypes {
+//                 name
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "name" : "KindTest",
+//             "fields" : [
+//               {
+//                 "name" : "scalar",
+//                 "type" : {
+//                   "possibleTypes" : null
+//                 }
+//               },
+//               {
+//                 "name" : "object",
+//                 "type" : {
+//                   "possibleTypes" : null
+//                 }
+//               },
+//               {
+//                 "name" : "interface",
+//                 "type" : {
+//                   "possibleTypes" : [
+//                     {
+//                       "name" : "User"
+//                     }
+//                   ]
+//                 }
+//               },
+//               {
+//                 "name" : "union",
+//                 "type" : {
+//                   "possibleTypes" : [
+//                     {
+//                       "name" : "User"
+//                     },
+//                     {
+//                       "name" : "Date"
+//                     }
+//                   ]
+//                 }
+//               },
+//               {
+//                 "name" : "enum",
+//                 "type" : {
+//                   "possibleTypes" : null
+//                 }
+//               },
+//               {
+//                 "name" : "list",
+//                 "type" : {
+//                   "possibleTypes" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnull",
+//                 "type" : {
+//                   "possibleTypes" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnulllistnonnull",
+//                 "type" : {
+//                   "possibleTypes" : null
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("enumValues query") {
+//     val query = """
+//       {
+//         __type(name: "KindTest") {
+//           name
+//           fields {
+//             name
+//             type {
+//               enumValues {
+//                 name
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "name" : "KindTest",
+//             "fields" : [
+//               {
+//                 "name" : "scalar",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "object",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "interface",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "union",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "enum",
+//                 "type" : {
+//                   "enumValues" : [
+//                     {
+//                       "name" : "A"
+//                     },
+//                     {
+//                       "name" : "C"
+//                     }
+//                   ]
+//                 }
+//               },
+//               {
+//                 "name" : "list",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnull",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "nonnulllistnonnull",
+//                 "type" : {
+//                   "enumValues" : null
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("deprecation excluded") {
+//     val query = """
+//       {
+//         __type(name: "DeprecationTest") {
+//           fields {
+//             name
+//             type {
+//               fields(includeDeprecated: false) {
+//                 name
+//                 isDeprecated
+//                 deprecationReason
+//               }
+//               enumValues(includeDeprecated: false) {
+//                 name
+//                 isDeprecated
+//                 deprecationReason
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "fields" : [
+//               {
+//                 "name" : "user",
+//                 "type" : {
+//                   "fields" : [
+//                     {
+//                       "name" : "id",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     },
+//                     {
+//                       "name" : "name",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     },
+//                     {
+//                       "name" : "birthday",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     }
+//                   ],
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "flags",
+//                 "type" : {
+//                   "fields" : null,
+//                   "enumValues" : [
+//                     {
+//                       "name" : "A",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     },
+//                     {
+//                       "name" : "C",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     }
+//                   ]
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("deprecation included") {
+//     val query = """
+//       {
+//         __type(name: "DeprecationTest") {
+//           fields {
+//             name
+//             type {
+//               fields(includeDeprecated: true) {
+//                 name
+//                 isDeprecated
+//                 deprecationReason
+//               }
+//               enumValues(includeDeprecated: true) {
+//                 name
+//                 isDeprecated
+//                 deprecationReason
+//               }
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__type" : {
+//             "fields" : [
+//               {
+//                 "name" : "user",
+//                 "type" : {
+//                   "fields" : [
+//                     {
+//                       "name" : "id",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     },
+//                     {
+//                       "name" : "name",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     },
+//                     {
+//                       "name" : "age",
+//                       "isDeprecated" : true,
+//                       "deprecationReason" : "Use birthday instead"
+//                     },
+//                     {
+//                       "name" : "birthday",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     }
+//                   ],
+//                   "enumValues" : null
+//                 }
+//               },
+//               {
+//                 "name" : "flags",
+//                 "type" : {
+//                   "fields" : null,
+//                   "enumValues" : [
+//                     {
+//                       "name" : "A",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     },
+//                     {
+//                       "name" : "B",
+//                       "isDeprecated" : true,
+//                       "deprecationReason" : "Deprecation test"
+//                     },
+//                     {
+//                       "name" : "C",
+//                       "isDeprecated" : false,
+//                       "deprecationReason" : null
+//                     }
+//                   ]
+//                 }
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("simple schema query") {
+//     val query = """
+//       {
+//         __schema {
+//           queryType { name }
+//           mutationType { name }
+//           subscriptionType { name }
+//           types { name }
+//           directives { name }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__schema" : {
+//             "queryType" : {
+//               "name" : "Query"
+//             },
+//             "mutationType" : null,
+//             "subscriptionType" : null,
+//             "types" : [
+//               {
+//                 "name" : "Query"
+//               },
+//               {
+//                 "name" : "User"
+//               },
+//               {
+//                 "name" : "Profile"
+//               },
+//               {
+//                 "name" : "Date"
+//               },
+//               {
+//                 "name" : "Choice"
+//               },
+//               {
+//                 "name" : "Flags"
+//               },
+//               {
+//                 "name" : "KindTest"
+//               },
+//               {
+//                 "name" : "DeprecationTest"
+//               }
+//             ],
+//             "directives" : [
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res0 = TestMapping.compileAndRun(query)
+//     val res = stripStandardTypes(res0)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("standard introspection query") {
+//     val query = """
+//       |query IntrospectionQuery {
+//       |  __schema {
+//       |    queryType { name }
+//       |    mutationType { name }
+//       |    subscriptionType { name }
+//       |    types {
+//       |      ...FullType
+//       |    }
+//       |    directives {
+//       |      name
+//       |      description
+//       |      locations
+//       |      args {
+//       |        ...InputValue
+//       |      }
+//       |    }
+//       |  }
+//       |}
+//       |
+//       |fragment FullType on __Type {
+//       |  kind
+//       |  name
+//       |  description
+//       |  fields(includeDeprecated: true) {
+//       |    name
+//       |    description
+//       |    args {
+//       |      ...InputValue
+//       |    }
+//       |    type {
+//       |      ...TypeRef
+//       |    }
+//       |    isDeprecated
+//       |    deprecationReason
+//       |  }
+//       |  inputFields {
+//       |    ...InputValue
+//       |  }
+//       |  interfaces {
+//       |    ...TypeRef
+//       |  }
+//       |  enumValues(includeDeprecated: true) {
+//       |    name
+//       |    description
+//       |    isDeprecated
+//       |    deprecationReason
+//       |  }
+//       |  possibleTypes {
+//       |    ...TypeRef
+//       |  }
+//       |}
+//       |
+//       |fragment InputValue on __InputValue {
+//       |  name
+//       |  description
+//       |  type { ...TypeRef }
+//       |  defaultValue
+//       |}
+//       |
+//       |fragment TypeRef on __Type {
+//       |  kind
+//       |  name
+//       |  ofType {
+//       |    kind
+//       |    name
+//       |    ofType {
+//       |      kind
+//       |      name
+//       |      ofType {
+//       |        kind
+//       |        name
+//       |        ofType {
+//       |          kind
+//       |          name
+//       |          ofType {
+//       |            kind
+//       |            name
+//       |            ofType {
+//       |              kind
+//       |              name
+//       |              ofType {
+//       |                kind
+//       |                name
+//       |              }
+//       |            }
+//       |          }
+//       |        }
+//       |      }
+//       |    }
+//       |  }
+//       |}
+//     """.stripMargin.trim
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "__schema" : {
+//             "queryType" : {
+//               "name" : "Query"
+//             },
+//             "mutationType" : {
+//               "name" : "Mutation"
+//             },
+//             "subscriptionType" : {
+//               "name" : "Subscription"
+//             },
+//             "types" : [
+//               {
+//                 "kind" : "OBJECT",
+//                 "name" : "Query",
+//                 "description" : null,
+//                 "fields" : [
+//                   {
+//                     "name" : "users",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "NON_NULL",
+//                       "name" : null,
+//                       "ofType" : {
+//                         "kind" : "LIST",
+//                         "name" : null,
+//                         "ofType" : {
+//                           "kind" : "NON_NULL",
+//                           "name" : null,
+//                           "ofType" : {
+//                             "kind" : "OBJECT",
+//                             "name" : "User",
+//                             "ofType" : null
+//                           }
+//                         }
+//                       }
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   },
+//                   {
+//                     "name" : "profiles",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "NON_NULL",
+//                       "name" : null,
+//                       "ofType" : {
+//                         "kind" : "LIST",
+//                         "name" : null,
+//                         "ofType" : {
+//                           "kind" : "NON_NULL",
+//                           "name" : null,
+//                           "ofType" : {
+//                             "kind" : "INTERFACE",
+//                             "name" : "Profile",
+//                             "ofType" : null
+//                           }
+//                         }
+//                       }
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   }
+//                 ],
+//                 "inputFields" : null,
+//                 "interfaces" : [
+//                 ],
+//                 "enumValues" : null,
+//                 "possibleTypes" : null
+//               },
+//               {
+//                 "kind" : "OBJECT",
+//                 "name" : "Subscription",
+//                 "description" : null,
+//                 "fields" : [
+//                   {
+//                     "name" : "dummy",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "NON_NULL",
+//                       "name" : null,
+//                       "ofType" : {
+//                         "kind" : "SCALAR",
+//                         "name" : "Int",
+//                         "ofType" : null
+//                       }
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   }
+//                 ],
+//                 "inputFields" : null,
+//                 "interfaces" : [
+//                 ],
+//                 "enumValues" : null,
+//                 "possibleTypes" : null
+//               },
+//               {
+//                 "kind" : "OBJECT",
+//                 "name" : "Mutation",
+//                 "description" : null,
+//                 "fields" : [
+//                   {
+//                     "name" : "dummy",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "NON_NULL",
+//                       "name" : null,
+//                       "ofType" : {
+//                         "kind" : "SCALAR",
+//                         "name" : "Int",
+//                         "ofType" : null
+//                       }
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   }
+//                 ],
+//                 "inputFields" : null,
+//                 "interfaces" : [
+//                 ],
+//                 "enumValues" : null,
+//                 "possibleTypes" : null
+//               },
+//               {
+//                 "kind" : "INTERFACE",
+//                 "name" : "Profile",
+//                 "description" : "Profile interface type",
+//                 "fields" : [
+//                   {
+//                     "name" : "id",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "SCALAR",
+//                       "name" : "String",
+//                       "ofType" : null
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   }
+//                 ],
+//                 "inputFields" : null,
+//                 "interfaces" : null,
+//                 "enumValues" : null,
+//                 "possibleTypes" : [
+//                   {
+//                     "kind" : "OBJECT",
+//                     "name" : "User",
+//                     "ofType" : null
+//                   }
+//                 ]
+//               },
+//               {
+//                 "kind" : "OBJECT",
+//                 "name" : "User",
+//                 "description" : "User object type",
+//                 "fields" : [
+//                   {
+//                     "name" : "id",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "SCALAR",
+//                       "name" : "String",
+//                       "ofType" : null
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   },
+//                   {
+//                     "name" : "name",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "SCALAR",
+//                       "name" : "String",
+//                       "ofType" : null
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   },
+//                   {
+//                     "name" : "age",
+//                     "description" : null,
+//                     "args" : [
+//                     ],
+//                     "type" : {
+//                       "kind" : "SCALAR",
+//                       "name" : "Int",
+//                       "ofType" : null
+//                     },
+//                     "isDeprecated" : false,
+//                     "deprecationReason" : null
+//                   }
+//                 ],
+//                 "inputFields" : null,
+//                 "interfaces" : [
+//                   {
+//                     "kind" : "INTERFACE",
+//                     "name" : "Profile",
+//                     "ofType" : null
+//                   }
+//                 ],
+//                 "enumValues" : null,
+//                 "possibleTypes" : null
+//               }
+//             ],
+//             "directives" : [
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res0 = SmallMapping.compileAndRun(query)
+//     val res = stripStandardTypes(res0)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("typename query") {
+//     val query = """
+//       {
+//         users {
+//           __typename
+//           renamed: __typename
+//           name
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "users" : [
+//             {
+//               "__typename" : "User",
+//               "renamed" : "User",
+//               "name" : "Luke Skywalker"
+//             }
+//           ]
+//         }
+//       }
+//     """
+
+//     val res = SmallMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("typename query with narrowing") {
+//     val query = """
+//       {
+//         profiles {
+//           __typename
+//           id
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "profiles" : [
+//             {
+//               "__typename" : "User",
+//               "id" : "1000"
+//             }
+//           ]
+//         }
+//       }
+//     """
+
+//     val res = SmallMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("mixed query") {
+//     val query = """
+//       {
+//         users {
+//           name
+//         }
+//         __type(name: "User") {
+//           name
+//           fields {
+//             name
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "users" : [
+//             {
+//               "name" : "Luke Skywalker"
+//             }
+//           ],
+//           "__type" : {
+//             "name": "User",
+//             "fields" : [
+//               {
+//                 "name" : "id"
+//               },
+//               {
+//                 "name" : "name"
+//               },
+//               {
+//                 "name" : "age"
+//               }
+//             ]
+//           }
+//         }
+//       }
+//     """
+
+//     val res = SmallMapping.compileAndRun(query)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("introspection disabled") {
+//     val query = """
+//       {
+//         __type(name: "User") {
+//           name
+//           fields {
+//             name
+//             type {
+//               name
+//             }
+//           }
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "errors" : [
+//           {
+//             "message" : "Unknown field '__type' in 'Query'"
+//           }
+//         ]
+//       }
+//     """
+
+//     val res = TestMapping.compileAndRun(query, introspectionLevel = Disabled)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+
+//   test("introspection disabled typename allowed") {
+//     val query = """
+//       {
+//         users {
+//           __typename
+//           renamed: __typename
+//           name
+//         }
+//       }
+//     """
+
+//     val expected = json"""
+//       {
+//         "data" : {
+//           "users" : [
+//             {
+//               "__typename" : "User",
+//               "renamed" : "User",
+//               "name" : "Luke Skywalker"
+//             }
+//           ]
+//         }
+//       }
+//     """
+
+//     val res = SmallMapping.compileAndRun(query, introspectionLevel = TypenameOnly)
+//     //println(res)
+
+//     assert(res == expected)
+//   }
+// }
+
+// object TestMapping extends Mapping[Id] {
+//   val schema =
+//     schema"""
+//       type Query {
+//         users: [User!]!
+//       }
+
+//       "User object type"
+//       type User implements Profile {
+//         id: String
+//         name: String
+//         age: Int @deprecated(reason: "Use birthday instead")
+//         birthday: Date
+//       }
+
+//       "Profile interface type"
+//       interface Profile {
+//         id: String
+//       }
+
+//       "Date object type"
+//       type Date {
+//         day: Int
+//         month: Int
+//         year: Int
+//       }
+
+//       "Choice union type"
+//       union Choice = User | Date
+
+//       "Flags enum type"
+//       enum Flags {
+//         A
+//         B @deprecated(reason: "Deprecation test")
+//         C
+//       }
+
+//       type KindTest {
+//         "Scalar field"
+//         scalar: Int
+//         "Object field"
+//         object: User
+//         "Interface field"
+//         interface: Profile
+//         "Union field"
+//         union: Choice
+//         "Enum field"
+//         enum: Flags
+//         "List field"
+//         list: [Int]
+//         "Nonnull field"
+//         nonnull: Int!
+//         "Nonnull list of nonnull field"
+//         nonnulllistnonnull: [Int!]!
+//       }
+
+//       type DeprecationTest {
+//         user: User
+//         flags: Flags
+//       }
+//     """
+
+//   val typeMappings = Nil
+// }
+
+// object SmallData {
+//   trait Profile {
+//     def id: Option[String]
+//   }
+//   case class User(id: Option[String], name: Option[String], age: Option[Int]) extends Profile
+//   val users = List(
+//     User(Some("1000"), Some("Luke Skywalker"), Some(30))
+//   )
+// }
+
+// object SmallMapping extends ValueMapping[Id] {
+//   import SmallData._
+
+//   val schema =
+//     schema"""
+//       type Query {
+//         users: [User!]!
+//         profiles: [Profile!]!
+//       }
+//       type Subscription {
+//         dummy: Int!
+//       }
+//       type Mutation {
+//         dummy: Int!
+//       }
+//       "Profile interface type"
+//       interface Profile {
+//         id: String
+//       }
+//       "User object type"
+//       type User implements Profile {
+//         id: String
+//         name: String
+//         age: Int
+//       }
+//     """
+
+//   val QueryType = schema.queryType
+//   val UserType = schema.ref("User")
+//   val ProfileType = schema.ref("Profile")
+
+//   val typeMappings =
+//     List(
+//       ObjectMapping(
+//         tpe = QueryType,
+//         fieldMappings =
+//           List(
+//             ValueRoot("users", users),
+//             ValueRoot("profiles", users)
+//           )
+//       ),
+//       ValueObjectMapping[User](
+//         tpe = UserType,
+//         fieldMappings =
+//           List(
+//             ValueField("name", _.name),
+//             ValueField("age", _.age)
+//           )
+//       ),
+//       ValueObjectMapping[Profile](
+//         tpe = ProfileType,
+//         fieldMappings =
+//           List(
+//             ValueField("id", _.id)
+//           )
+//       )
+//   )
+// }

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -9,7 +9,7 @@ import cats.implicits._
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
 
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 object StarWarsData {
@@ -210,9 +210,9 @@ object StarWarsMapping extends ValueMapping[Id] {
     QueryType -> {
       case Select("hero", List(Binding("episode", TypedEnumValue(e))), child) =>
         val episode = Episode.values.find(_.toString == e.name).get
-        Select("hero", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(hero(episode).id)), child))).rightIor
+        Select("hero", Nil, Unique(Filter(Eql(CharacterType / "id", Const(hero(episode).id)), child))).rightIor
       case Select(f@("character" | "human" | "droid"), List(Binding("id", IDValue(id))), child) =>
-        Select(f, Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select(f, Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).rightIor
       case Select("characters", List(Binding("offset", IntValue(offset)), Binding("limit", IntValue(limit))), child) =>
         Select("characters", Nil, Limit(limit, Offset(offset, child))).rightIor
     },

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -13,6 +13,7 @@ import edu.gemini.grackle.doobie.postgres.DoobieMonitor
 import edu.gemini.grackle.sql.SqlStatsMonitor
 
 import edu.gemini.grackle.sql.test._
+import edu.gemini.grackle.Mapping
 
 final class ArrayJoinSpec extends DoobieDatabaseSuite with SqlArrayJoinSpec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlArrayJoinMapping[IO]
@@ -124,7 +125,7 @@ final class WorldSpec extends DoobieDatabaseSuite with SqlWorldSpec {
 final class WorldCompilerSpec extends DoobieDatabaseSuite with SqlWorldCompilerSpec {
   type Fragment = doobie.Fragment
 
-  def mapping: IO[(QueryExecutor[IO, Json], SqlStatsMonitor[IO,Fragment])] =
+  def mapping: IO[(Mapping[IO], SqlStatsMonitor[IO,Fragment])] =
     DoobieMonitor.statsMonitor[IO].map(mon => (new DoobieTestMapping(xa, mon) with SqlWorldMapping[IO], mon))
 
   def simpleRestrictedQuerySql: String =

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -14,7 +14,7 @@ import io.circe.Json
 
 import edu.gemini.grackle.syntax._
 import Cursor.Context
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ScalarType._
@@ -209,11 +209,11 @@ object StarWarsMapping extends GenericMapping[Id] {
     QueryType -> {
       case Select("hero", List(Binding("episode", TypedEnumValue(e))), child) =>
         Episode.values.find(_.toString == e.name).map { episode =>
-          Select("hero", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(hero(episode).id)), child))).rightIor
+          Select("hero", Nil, Unique(Filter(Eql(CharacterType / "id", Const(hero(episode).id)), child))).rightIor
         }.getOrElse(mkErrorResult(s"Unknown episode '${e.name}'"))
 
       case Select(f@("character" | "human" | "droid"), List(Binding("id", IDValue(id))), child) =>
-        Select(f, Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select(f, Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).rightIor
     },
     CharacterType -> numberOfFriends,
     HumanType -> numberOfFriends,

--- a/modules/generic/src/test/scala/recursion.scala
+++ b/modules/generic/src/test/scala/recursion.scala
@@ -9,7 +9,7 @@ import cats.implicits._
 import cats.tests.CatsSuite
 
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.mkOneError
 import semiauto._
@@ -85,7 +85,7 @@ object MutualRecursionMapping extends GenericMapping[Id] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select(f@("programmeById" | "productionById"), List(Binding("id", IDValue(id))), child) =>
-        Select(f, Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select(f, Nil, Unique(Filter(Eql(ProgrammeType / "id", Const(id)), child))).rightIor
     }
   ))
 }

--- a/modules/generic/src/test/scala/scalars.scala
+++ b/modules/generic/src/test/scala/scalars.scala
@@ -14,7 +14,7 @@ import cats.tests.CatsSuite
 import io.circe.Encoder
 
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 import semiauto._
 
@@ -179,15 +179,15 @@ object MovieMapping extends GenericMapping[Id] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("movieById", List(Binding("id", UUIDValue(id))), child) =>
-        Select("movieById", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("movieById", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).rightIor
       case Select("moviesByGenre", List(Binding("genre", GenreValue(genre))), child) =>
-        Select("moviesByGenre", Nil, Filter(Eql(UniquePath(List("genre")), Const(genre)), child)).rightIor
+        Select("moviesByGenre", Nil, Filter(Eql(MovieType / "genre", Const(genre)), child)).rightIor
       case Select("moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to))), child) =>
         Select("moviesReleasedBetween", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("releaseDate")), Const(from))),
-              Lt(UniquePath(List("releaseDate")), Const(to))
+              Not(Lt(MovieType / "releaseDate", Const(from))),
+              Lt(MovieType / "releaseDate", Const(to))
             ),
             child
           )
@@ -195,14 +195,14 @@ object MovieMapping extends GenericMapping[Id] {
       case Select("moviesLongerThan", List(Binding("duration", IntervalValue(duration))), child) =>
         Select("moviesLongerThan", Nil,
           Filter(
-            Not(Lt(UniquePath(List("duration")), Const(duration))),
+            Not(Lt(MovieType / "duration", Const(duration))),
             child
           )
         ).rightIor
       case Select("moviesShownLaterThan", List(Binding("time", TimeValue(time))), child) =>
         Select("moviesShownLaterThan", Nil,
           Filter(
-            Not(Lt(UniquePath(List("showTime")), Const(time))),
+            Not(Lt(MovieType / "showTime", Const(time))),
             child
           )
         ).rightIor
@@ -210,8 +210,8 @@ object MovieMapping extends GenericMapping[Id] {
         Select("moviesShownBetween", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("nextShowing")), Const(from))),
-              Lt(UniquePath(List("nextShowing")), Const(to))
+              Not(Lt(MovieType / "nextShowing", Const(from))),
+              Lt(MovieType / "nextShowing", Const(to))
             ),
             child
           )

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -13,6 +13,7 @@ import edu.gemini.grackle.skunk.SkunkMonitor
 import edu.gemini.grackle.sql.SqlStatsMonitor
 
 import edu.gemini.grackle.sql.test._
+import edu.gemini.grackle.Mapping
 
 final class ArrayJoinSpec extends SkunkDatabaseSuite with SqlArrayJoinSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlArrayJoinMapping[IO]
@@ -127,7 +128,7 @@ final class WorldSpec extends SkunkDatabaseSuite with SqlWorldSpec {
 final class WorldCompilerSpec extends SkunkDatabaseSuite with SqlWorldCompilerSpec {
   type Fragment = skunk.AppliedFragment
 
-  def mapping: IO[(QueryExecutor[IO, Json], SqlStatsMonitor[IO,Fragment])] =
+  def mapping: IO[(Mapping[IO], SqlStatsMonitor[IO,Fragment])] =
     SkunkMonitor.statsMonitor[IO].map(mon => (new SkunkTestMapping(pool, mon) with SqlWorldMapping[IO], mon))
 
   def simpleRestrictedQuerySql: String =

--- a/modules/skunk/src/test/scala/subscription/SubscriptionMapping.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionMapping.scala
@@ -11,7 +11,6 @@ import skunk.implicits._
 
 import edu.gemini.grackle._
 import syntax._
-import Path._
 import Predicate._
 import Query._
 import QueryCompiler._
@@ -93,7 +92,7 @@ trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
               for {
                 s  <- fs2.Stream.resource(pool)
                 id <- s.channel(id"city_channel").listen(256).map(_.value.toInt)
-                qʹ  = Unique(Filter(Eql(UniquePath(List("id")), Const(id)), q))
+                qʹ  = Unique(Filter(Eql(CityType / "id", Const(id)), q))
               } yield Result((qʹ, e))
             }
           ),
@@ -104,7 +103,7 @@ trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).rightIor
     },
   ))
 }

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -750,7 +750,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   /** Returns the aliased columns corresponding to `term` in `context` */
   def columnForSqlTerm[T](context: Context, term: Term[T]): Option[SqlColumn] =
     term match {
-      case termPath: PathTerm[_] =>
+      case termPath: PathTerm =>
         context.forPath(termPath.path.init).flatMap { parentContext =>
           columnForAtomicField(parentContext, termPath.path.last)
         }
@@ -774,7 +774,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   /** Returns the `Encoder` for the given term in `context` */
   def encoderForTerm(context: Context, term: Term[_]): Option[Encoder] =
     term match {
-      case pathTerm: PathTerm[_] =>
+      case pathTerm: PathTerm =>
         for {
           cr <- columnForSqlTerm(context, pathTerm) // encoder is independent of query aliases
         } yield toEncoder(cr.codec)
@@ -834,7 +834,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   /** Is `term` in `context`expressible in SQL? */
   def isSqlTerm(context: Context, term: Term[_]): Boolean =
     term.forall {
-      case termPath: PathTerm[_] =>
+      case termPath: PathTerm =>
         context.forPath(termPath.path.init).map { parentContext =>
           !isComputedField(parentContext, termPath.path.last)
         }.getOrElse(true)
@@ -1145,7 +1145,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       def loop(term: Term[_], acc: List[List[String]]): List[List[String]] = {
         term match {
           case Const(_)         => acc
-          case pathTerm: PathTerm[_]   => pathTerm.path :: acc
+          case pathTerm: PathTerm  => pathTerm.path :: acc
           case And(x, y)        => loop(y, loop(x, acc))
           case Or(x, y)         => loop(y, loop(x, acc))
           case Not(x)           => loop(x, acc)
@@ -1178,7 +1178,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     def whereCols(f: Term[_] => SqlColumn, pred: Predicate): List[SqlColumn] = {
       def loop[T](term: T): List[SqlColumn] =
         term match {
-          case _: PathTerm[_]          => f(term.asInstanceOf[Term[_]]) :: Nil
+          case _: PathTerm      => f(term.asInstanceOf[Term[_]]) :: Nil
           case _: SqlColumnTerm => f(term.asInstanceOf[Term[_]]) :: Nil
           case Const(_)         => Nil
           case And(x, y)        => loop(x) ++ loop(y)
@@ -1212,7 +1212,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     def contextualiseWhereTerms(context: Context, owner: ColumnOwner, pred: Predicate): Predicate = {
       def loop[T](term: T): T =
         (term match {
-          case _: PathTerm[_]          => SqlColumnTerm(contextualiseTerm(context, owner, term.asInstanceOf[Term[_]]))
+          case _: PathTerm      => SqlColumnTerm(contextualiseTerm(context, owner, term.asInstanceOf[Term[_]]))
           case _: SqlColumnTerm => SqlColumnTerm(contextualiseTerm(context, owner, term.asInstanceOf[Term[_]]))
           case Const(_)         => term
           case And(x, y)        => And(loop(x), loop(y))
@@ -1247,7 +1247,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       def loop[T](term: T): T =
         (term match {
           case SqlColumnTerm(col) => SqlColumnTerm(col.subst(from, to))
-          case _: PathTerm[_]            => term
+          case _: PathTerm        => term
           case Const(_)           => term
           case And(x, y)          => And(loop(x), loop(y))
           case Or(x, y)           => Or(loop(x), loop(y))
@@ -1315,7 +1315,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           case SqlColumnTerm(col) =>
             col.toRefFragment(false)
 
-          case pathTerm: PathTerm[_] =>
+          case pathTerm: PathTerm =>
             sys.error(s"Unresolved term $pathTerm in WHERE clause")
 
           case True =>
@@ -1463,7 +1463,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
       term match {
         case SqlColumnTerm(col) => subst(col)
-        case pathTerm: PathTerm[_] =>
+        case pathTerm: PathTerm =>
           columnForSqlTerm(context, pathTerm).map(subst).getOrElse(sys.error(s"No column for term $pathTerm"))
 
         case other =>
@@ -2865,7 +2865,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
           case FilterOrderByOffsetLimit(pred, oss, offset, lim, child) =>
             val filterPaths = pred.map(SqlQuery.wherePaths).getOrElse(Nil).distinct
-            val orderPaths = oss.map(_.map(_.term).collect { case path: PathTerm[_] => path.path }).getOrElse(Nil).distinct
+            val orderPaths = oss.map(_.map(_.term).collect { case path: PathTerm => path.path }).getOrElse(Nil).distinct
             val filterOrderPaths = (filterPaths ++ orderPaths).distinct
 
             if (pred.map(p => !isSqlTerm(context, p)).getOrElse(false)) {

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -750,7 +750,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   /** Returns the aliased columns corresponding to `term` in `context` */
   def columnForSqlTerm[T](context: Context, term: Term[T]): Option[SqlColumn] =
     term match {
-      case termPath: Path =>
+      case termPath: PathTerm[_] =>
         context.forPath(termPath.path.init).flatMap { parentContext =>
           columnForAtomicField(parentContext, termPath.path.last)
         }
@@ -774,7 +774,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   /** Returns the `Encoder` for the given term in `context` */
   def encoderForTerm(context: Context, term: Term[_]): Option[Encoder] =
     term match {
-      case pathTerm: Path =>
+      case pathTerm: PathTerm[_] =>
         for {
           cr <- columnForSqlTerm(context, pathTerm) // encoder is independent of query aliases
         } yield toEncoder(cr.codec)
@@ -834,7 +834,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
   /** Is `term` in `context`expressible in SQL? */
   def isSqlTerm(context: Context, term: Term[_]): Boolean =
     term.forall {
-      case termPath: Path =>
+      case termPath: PathTerm[_] =>
         context.forPath(termPath.path.init).map { parentContext =>
           !isComputedField(parentContext, termPath.path.last)
         }.getOrElse(true)
@@ -1145,7 +1145,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       def loop(term: Term[_], acc: List[List[String]]): List[List[String]] = {
         term match {
           case Const(_)         => acc
-          case pathTerm: Path   => pathTerm.path :: acc
+          case pathTerm: PathTerm[_]   => pathTerm.path :: acc
           case And(x, y)        => loop(y, loop(x, acc))
           case Or(x, y)         => loop(y, loop(x, acc))
           case Not(x)           => loop(x, acc)
@@ -1178,7 +1178,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     def whereCols(f: Term[_] => SqlColumn, pred: Predicate): List[SqlColumn] = {
       def loop[T](term: T): List[SqlColumn] =
         term match {
-          case _: Path          => f(term.asInstanceOf[Term[_]]) :: Nil
+          case _: PathTerm[_]          => f(term.asInstanceOf[Term[_]]) :: Nil
           case _: SqlColumnTerm => f(term.asInstanceOf[Term[_]]) :: Nil
           case Const(_)         => Nil
           case And(x, y)        => loop(x) ++ loop(y)
@@ -1212,7 +1212,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     def contextualiseWhereTerms(context: Context, owner: ColumnOwner, pred: Predicate): Predicate = {
       def loop[T](term: T): T =
         (term match {
-          case _: Path          => SqlColumnTerm(contextualiseTerm(context, owner, term.asInstanceOf[Term[_]]))
+          case _: PathTerm[_]          => SqlColumnTerm(contextualiseTerm(context, owner, term.asInstanceOf[Term[_]]))
           case _: SqlColumnTerm => SqlColumnTerm(contextualiseTerm(context, owner, term.asInstanceOf[Term[_]]))
           case Const(_)         => term
           case And(x, y)        => And(loop(x), loop(y))
@@ -1247,7 +1247,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       def loop[T](term: T): T =
         (term match {
           case SqlColumnTerm(col) => SqlColumnTerm(col.subst(from, to))
-          case _: Path            => term
+          case _: PathTerm[_]            => term
           case Const(_)           => term
           case And(x, y)          => And(loop(x), loop(y))
           case Or(x, y)           => Or(loop(x), loop(y))
@@ -1315,7 +1315,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           case SqlColumnTerm(col) =>
             col.toRefFragment(false)
 
-          case pathTerm: Path =>
+          case pathTerm: PathTerm[_] =>
             sys.error(s"Unresolved term $pathTerm in WHERE clause")
 
           case True =>
@@ -1463,7 +1463,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
       term match {
         case SqlColumnTerm(col) => subst(col)
-        case pathTerm: Path =>
+        case pathTerm: PathTerm[_] =>
           columnForSqlTerm(context, pathTerm).map(subst).getOrElse(sys.error(s"No column for term $pathTerm"))
 
         case other =>
@@ -2865,7 +2865,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
           case FilterOrderByOffsetLimit(pred, oss, offset, lim, child) =>
             val filterPaths = pred.map(SqlQuery.wherePaths).getOrElse(Nil).distinct
-            val orderPaths = oss.map(_.map(_.term).collect { case path: Path => path.path }).getOrElse(Nil).distinct
+            val orderPaths = oss.map(_.map(_.term).collect { case path: PathTerm[_] => path.path }).getOrElse(Nil).distinct
             val filterOrderPaths = (filterPaths ++ orderPaths).distinct
 
             if (pred.map(p => !isSqlTerm(context, p)).getOrElse(false)) {

--- a/modules/sql/src/test/scala/SqlCursorJsonMapping.scala
+++ b/modules/sql/src/test/scala/SqlCursorJsonMapping.scala
@@ -8,7 +8,6 @@ import io.circe.Json
 import edu.gemini.grackle._
 import syntax._
 import Query._
-import Path._
 import Predicate._
 import Value._
 import QueryCompiler._
@@ -93,7 +92,7 @@ trait SqlCursorJsonMapping[F[_]] extends SqlTestMapping[F] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("brands", List(Binding("id", IntValue(id))), child) =>
-        Select("brands", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("brands", Nil, Unique(Filter(Eql(BrandType / "id", Const(id)), child))).rightIor
     }
   ))
 }

--- a/modules/sql/src/test/scala/SqlGraphMapping.scala
+++ b/modules/sql/src/test/scala/SqlGraphMapping.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 trait SqlGraphMapping[F[_]] extends SqlTestMapping[F] {
@@ -73,7 +73,7 @@ trait SqlGraphMapping[F[_]] extends SqlTestMapping[F] {
   override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("node", List(Binding("id", IntValue(id))), child) =>
-        Select("node", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("node", Nil, Unique(Filter(Eql(NodeType / "id", Const(id)), child))).rightIor
 
       case other => other.rightIor
     }

--- a/modules/sql/src/test/scala/SqlInterfacesMapping.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesMapping.scala
@@ -9,7 +9,7 @@ import io.circe.Encoder
 
 import edu.gemini.grackle._
 import syntax._
-import Path._, Predicate._
+import Predicate._
 import Query._
 import QueryCompiler._
 
@@ -190,7 +190,7 @@ trait SqlInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
 
     def narrowPredicate(subtpe: Type): Option[Predicate] = {
       def mkPredicate(tpe: EntityType): Option[Predicate] =
-        Some(Eql(UniquePath(List("entityType")), Const(tpe)))
+        Some(Eql(EType / "entityType", Const(tpe)))
 
       subtpe match {
         case FilmType => mkPredicate(EntityType.Film)
@@ -203,7 +203,7 @@ trait SqlInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("films", Nil, child) =>
-        Select("films", Nil, Filter(Eql[EntityType](UniquePath(List("entityType")), Const(EntityType.Film)), child)).rightIor
+        Select("films", Nil, Filter(Eql[EntityType](FilmType / "entityType", Const(EntityType.Film)), child)).rightIor
     }
   ))
 

--- a/modules/sql/src/test/scala/SqlJsonbMapping.scala
+++ b/modules/sql/src/test/scala/SqlJsonbMapping.scala
@@ -9,7 +9,6 @@ import edu.gemini.grackle._
 import syntax._
 
 import Query._
-import Path._
 import Predicate._
 import Value._
 import QueryCompiler._
@@ -88,7 +87,7 @@ trait SqlJsonbMapping[F[_]] extends SqlTestMapping[F] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("record", List(Binding("id", IntValue(id))), child) =>
-        Select("record", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("record", Nil, Unique(Filter(Eql(RowType / "id", Const(id)), child))).rightIor
     }
   ))
 }

--- a/modules/sql/src/test/scala/SqlLikeMapping.scala
+++ b/modules/sql/src/test/scala/SqlLikeMapping.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 import sql.Like
 
@@ -86,13 +86,13 @@ trait SqlLikeMapping[F[_]] extends SqlTestMapping[F] {
   override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select(f@"likeNotNullableNotNullable", List(Binding("pattern", NonNullablePattern(pattern))), child) =>
-        Rename(f, Select("likes", Nil, Filter(Like(UniquePath(List("notNullable")), pattern, false), child))).rightIor
+        Rename(f, Select("likes", Nil, Filter(Like(LikeType / "notNullable", pattern, false), child))).rightIor
       case Select(f@"likeNotNullableNullable", List(Binding("pattern", NullablePattern(pattern))), child) =>
-        Rename(f, Select("likes", Nil, Filter(mkPredicate(UniquePath(List("notNullable")), pattern), child))).rightIor
+        Rename(f, Select("likes", Nil, Filter(mkPredicate(LikeType / "notNullable", pattern), child))).rightIor
       case Select(f@"likeNullableNotNullable", List(Binding("pattern", NonNullablePattern(pattern))), child) =>
-        Rename(f, Select("likes", Nil, Filter(Like(UniquePath(List("nullable")), pattern, false), child))).rightIor
+        Rename(f, Select("likes", Nil, Filter(Like(LikeType / "nullable", pattern, false), child))).rightIor
       case Select(f@"likeNullableNullable", List(Binding("pattern", NullablePattern(pattern))), child) =>
-        Rename(f, Select("likes", Nil, Filter(mkPredicate(UniquePath(List("nullable")), pattern), child))).rightIor
+        Rename(f, Select("likes", Nil, Filter(mkPredicate(LikeType / "nullable", pattern), child))).rightIor
 
       case other => other.rightIor
     }

--- a/modules/sql/src/test/scala/SqlMovieMapping.scala
+++ b/modules/sql/src/test/scala/SqlMovieMapping.scala
@@ -16,13 +16,12 @@ import io.circe.Encoder
 import edu.gemini.grackle._
 import syntax._
 import Query._
-import Path._
 import Predicate._
 import Value._
 import QueryCompiler._
 
 trait SqlMovieMapping[F[_]] extends SqlTestMapping[F] { self =>
-  
+
   def genre: Codec
   def feature: Codec
 
@@ -184,17 +183,17 @@ trait SqlMovieMapping[F[_]] extends SqlTestMapping[F] { self =>
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("movieById", List(Binding("id", UUIDValue(id))), child) =>
-        Select("movieById", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("movieById", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).rightIor
       case Select("moviesByGenre", List(Binding("genre", GenreValue(genre))), child) =>
-        Select("moviesByGenre", Nil, Filter(Eql(UniquePath(List("genre")), Const(genre)), child)).rightIor
+        Select("moviesByGenre", Nil, Filter(Eql(MovieType / "genre", Const(genre)), child)).rightIor
       case Select("moviesByGenres", List(Binding("genres", GenreListValue(genres))), child) =>
-        Select("moviesByGenres", Nil, Filter(In(UniquePath(List("genre")), genres), child)).rightIor
+        Select("moviesByGenres", Nil, Filter(In(MovieType / "genre", genres), child)).rightIor
       case Select("moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to))), child) =>
         Select("moviesReleasedBetween", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("releaseDate")), Const(from))),
-              Lt(UniquePath(List("releaseDate")), Const(to))
+              Not(Lt(MovieType / "releaseDate", Const(from))),
+              Lt(MovieType / "releaseDate", Const(to))
             ),
             child
           )
@@ -202,14 +201,14 @@ trait SqlMovieMapping[F[_]] extends SqlTestMapping[F] { self =>
       case Select("moviesLongerThan", List(Binding("duration", IntervalValue(duration))), child) =>
         Select("moviesLongerThan", Nil,
           Filter(
-            Not(Lt(UniquePath(List("duration")), Const(duration))),
+            Not(Lt(MovieType / "duration", Const(duration))),
             child
           )
         ).rightIor
       case Select("moviesShownLaterThan", List(Binding("time", TimeValue(time))), child) =>
         Select("moviesShownLaterThan", Nil,
           Filter(
-            Not(Lt(UniquePath(List("showTime")), Const(time))),
+            Not(Lt(MovieType / "showTime", Const(time))),
             child
           )
         ).rightIor
@@ -217,14 +216,14 @@ trait SqlMovieMapping[F[_]] extends SqlTestMapping[F] { self =>
         Select("moviesShownBetween", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("nextShowing")), Const(from))),
-              Lt(UniquePath(List("nextShowing")), Const(to))
+              Not(Lt(MovieType / "nextShowing", Const(from))),
+              Lt(MovieType / "nextShowing", Const(to))
             ),
             child
           )
         ).rightIor
       case Select("longMovies", Nil, child) =>
-        Select("longMovies", Nil, Filter(Eql(UniquePath(List("isLong")), Const(true)), child)).rightIor
+        Select("longMovies", Nil, Filter(Eql(MovieType / "isLong", Const(true)), child)).rightIor
     }
   ))
 

--- a/modules/sql/src/test/scala/SqlMutationMapping.scala
+++ b/modules/sql/src/test/scala/SqlMutationMapping.scala
@@ -8,7 +8,6 @@ import fs2.Stream
 
 import edu.gemini.grackle._
 import syntax._
-import Path._
 import Predicate._
 import Query._
 import QueryCompiler._
@@ -84,7 +83,7 @@ trait SqlMutationMapping[F[_]] extends SqlTestMapping[F] {
                 QueryInterpreter.mkErrorResult[(Query, Cursor.Env)](s"Implementation error: expected name, countryCode and population in $e.").pure[Stream[F,*]]
               case Some((name, cc, pop)) =>
                 Stream.eval(createCity(name, cc, pop)).map { id =>
-                  (Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child)), e).rightIor
+                  (Unique(Filter(Eql(CityType / "id", Const(id)), child)), e).rightIor
                 }
             }
           }),
@@ -113,7 +112,7 @@ trait SqlMutationMapping[F[_]] extends SqlTestMapping[F] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).rightIor
     },
     MutationType -> {
 
@@ -123,7 +122,7 @@ trait SqlMutationMapping[F[_]] extends SqlTestMapping[F] {
           Select("updatePopulation", Nil,
             // We could also do this in the SqlRoot's mutation, and in fact would need to do so if
             // the mutation generated a new id. But for now it seems easiest to do it here.
-            Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))
+            Unique(Filter(Eql(CityType / "id", Const(id)), child))
           )
         ).rightIor
 

--- a/modules/sql/src/test/scala/SqlProjectionMapping.scala
+++ b/modules/sql/src/test/scala/SqlProjectionMapping.scala
@@ -6,7 +6,6 @@ package edu.gemini.grackle.sql.test
 import cats.implicits._
 
 import edu.gemini.grackle._, syntax._
-import Path._
 import Predicate.{Const, Eql}
 import Query.{Binding, Filter, Select}
 import QueryCompiler.SelectElaborator
@@ -101,7 +100,7 @@ trait SqlProjectionMapping[F[_]] extends SqlTestMapping[F] {
     def unapply(input: ObjectValue): Option[Predicate] = {
       input.fields match {
         case List(("attr", BooleanValue(attr))) =>
-          Some(Eql(UniquePath(List("level1", "level2", "attr")), Const(Option(attr))))
+          Some(Eql(Level0Type / "level1" / "level2" / "attr", Const(Option(attr))))
         case _ => None
       }
     }
@@ -111,7 +110,7 @@ trait SqlProjectionMapping[F[_]] extends SqlTestMapping[F] {
     def unapply(input: ObjectValue): Option[Predicate] = {
       input.fields match {
         case List(("attr", BooleanValue(attr))) =>
-          Some(Eql(UniquePath(List("level2", "attr")), Const(Option(attr))))
+          Some(Eql(Level1Type / "level2" / "attr", Const(Option(attr))))
         case _ => None
       }
     }
@@ -121,7 +120,7 @@ trait SqlProjectionMapping[F[_]] extends SqlTestMapping[F] {
     def unapply(input: ObjectValue): Option[Predicate] = {
       input.fields match {
         case List(("attr", BooleanValue(attr))) =>
-          Some(Eql(UniquePath(List("attr")), Const(Option(attr))))
+          Some(Eql(Level2Type / "attr", Const(Option(attr))))
         case _ => None
       }
     }

--- a/modules/sql/src/test/scala/SqlRecursiveInterfacesMapping.scala
+++ b/modules/sql/src/test/scala/SqlRecursiveInterfacesMapping.scala
@@ -8,7 +8,7 @@ import io.circe.Encoder
 
 import edu.gemini.grackle._
 import syntax._
-import Path._, Predicate._
+import Predicate._
 
 trait SqlRecursiveInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
   def itemType: Codec
@@ -103,7 +103,7 @@ trait SqlRecursiveInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
 
     def narrowPredicate(subtpe: Type): Option[Predicate] = {
       def mkPredicate(tpe: ItemType): Option[Predicate] =
-        Some(Eql(UniquePath(List("itemType")), Const(tpe)))
+        Some(Eql(IType / "itemType", Const(tpe)))
 
       subtpe match {
         case ItemAType => mkPredicate(ItemType.ItemA)

--- a/modules/sql/src/test/scala/SqlSiblingListsMapping.scala
+++ b/modules/sql/src/test/scala/SqlSiblingListsMapping.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.implicits._
-import edu.gemini.grackle.Path.UniquePath
 import edu.gemini.grackle.Predicate.{Const, Eql}
 import edu.gemini.grackle.Query.{Binding, Filter, Select, Unique}
 import edu.gemini.grackle.syntax._
@@ -109,7 +108,7 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
     Map(
       QueryType -> {
         case Select("a", List(Binding("id", StringValue(id))), child) =>
-          Select("a", Nil, Unique(Filter(Eql(UniquePath[String](List("id")), Const(id)), child))).rightIor
+          Select("a", Nil, Unique(Filter(Eql(AType / "id", Const(id)), child))).rightIor
         case other => other.rightIor
       }
     )

--- a/modules/sql/src/test/scala/SqlTreeMapping.scala
+++ b/modules/sql/src/test/scala/SqlTreeMapping.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 trait SqlTreeMapping[F[_]] extends SqlTestMapping[F] {
@@ -56,7 +56,7 @@ trait SqlTreeMapping[F[_]] extends SqlTestMapping[F] {
   override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("bintree", List(Binding("id", IntValue(id))), child) =>
-        Select("bintree", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("bintree", Nil, Unique(Filter(Eql(BinTreeType / "id", Const(id)), child))).rightIor
 
       case other => other.rightIor
     }

--- a/modules/sql/src/test/scala/SqlUnionsMapping.scala
+++ b/modules/sql/src/test/scala/SqlUnionsMapping.scala
@@ -5,7 +5,7 @@ package edu.gemini.grackle.sql.test
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Path._, Predicate._
+import Predicate._
 
 trait SqlUnionsMapping[F[_]] extends SqlTestMapping[F] {
 
@@ -82,7 +82,7 @@ trait SqlUnionsMapping[F[_]] extends SqlTestMapping[F] {
 
     def narrowPredicate(subtpe: Type): Option[Predicate] = {
       def mkPredicate(tpe: String): Option[Predicate] =
-        Some(Eql(UniquePath(List("itemType")), Const(tpe)))
+        Some(Eql(ItemType / "itemType", Const(tpe)))
 
       subtpe match {
         case ItemAType => mkPredicate("ItemA")

--- a/modules/sql/src/test/scala/SqlWorldMapping.scala
+++ b/modules/sql/src/test/scala/SqlWorldMapping.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import edu.gemini.grackle._
 import sql.Like
 import syntax._
-import Query._, Path._, Predicate._, Value._
+import Query._, Predicate._, Value._
 import QueryCompiler._
 
 trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
@@ -162,10 +162,10 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
     QueryType -> {
 
       case Select("country", List(Binding("code", StringValue(code))), child) =>
-        Select("country", Nil, Unique(Filter(Eql(UniquePath(List("code")), Const(code)), child))).rightIor
+        Select("country", Nil, Unique(Filter(Eql(CountryType / "code", Const(code)), child))).rightIor
 
       case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).rightIor
 
       case Select("countries", List(Binding("limit", IntValue(num)), Binding("offset", IntValue(off)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop))), child) =>
         def limit(query: Query): Query =
@@ -178,15 +178,15 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
 
         def order(query: Query): Query = {
           if (byPop)
-            OrderBy(OrderSelections(List(OrderSelection(UniquePath[Int](List("population"))))), query)
+            OrderBy(OrderSelections(List(OrderSelection[Int](CountryType / "population"))), query)
           else if (num > 0 || off > 0)
-            OrderBy(OrderSelections(List(OrderSelection(UniquePath[String](List("code"))))), query)
+            OrderBy(OrderSelections(List(OrderSelection[String](CountryType / "code"))), query)
           else query
         }
 
         def filter(query: Query): Query =
           if (min == 0) query
-          else Filter(GtEql(UniquePath(List("population")), Const(min)), query)
+          else Filter(GtEql(CountryType / "population", Const(min)), query)
 
         Select("countries", Nil, limit(offset(order(filter(child))))).rightIor
 
@@ -194,34 +194,34 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
         if (namePattern == "%")
           Select("cities", Nil, child).rightIor
         else
-          Select("cities", Nil, Filter(Like(UniquePath(List("name")), namePattern, true), child)).rightIor
+          Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), child)).rightIor
 
       case Select("language", List(Binding("language", StringValue(language))), child) =>
-        Select("language", Nil, Unique(Filter(Eql(UniquePath(List("language")), Const(language)), child))).rightIor
+        Select("language", Nil, Unique(Filter(Eql(LanguageType / "language", Const(language)), child))).rightIor
 
       case Select("search", List(Binding("minPopulation", IntValue(min)), Binding("indepSince", IntValue(year))), child) =>
         Select("search", Nil,
           Filter(
             And(
-              Not(Lt(UniquePath(List("population")), Const(min))),
-              Not(Lt(UniquePath(List("indepyear")), Const(Option(year))))
+              Not(Lt(CountryType / "population", Const(min))),
+              Not(Lt(CountryType / "indepyear", Const(Option(year))))
             ),
             child
           )
         ).rightIor
 
       case Select("search2", List(Binding("indep", BooleanValue(indep)), Binding("limit", IntValue(num))), child) =>
-        Select("search2", Nil, Limit(num, Filter(IsNull[Int](UniquePath(List("indepyear")), isNull = !indep), child))).rightIor
+        Select("search2", Nil, Limit(num, Filter(IsNull[Int](CountryType / "indepyear", isNull = !indep), child))).rightIor
     },
     CountryType -> {
       case Select("numCities", List(Binding("namePattern", AbsentValue)), Empty) =>
         Count("numCities", Select("cities", Nil, Select("name", Nil, Empty))).rightIor
 
       case Select("numCities", List(Binding("namePattern", StringValue(namePattern))), Empty) =>
-        Count("numCities", Select("cities", Nil, Filter(Like(UniquePath(List("name")), namePattern, true), Select("name", Nil, Empty)))).rightIor
+        Count("numCities", Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), Select("name", Nil, Empty)))).rightIor
 
       case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).rightIor
     }
   ))
 }


### PR DESCRIPTION
This collapses the distinction between `UniquePath` and `ListPath` by requiring paths to specify their originating types. One can construct a path thus:

```scala
Path.from(tpe) // an empty path rooted at tpe
```

And can extend a path via `/`:

```scala
path / "a" / "b" / "c" // path extended by three more elements
```

As a convenience one can construct and extend a path via the new `/` method on `Type`:

```scala
tpe / "a" / "b" // an empty path rooted a t, extended with "a" and then "b"
```

In order to turn a path into a term one can call `.asTerm[A]` for any type `A`. This conversion is also applied implicitly, so a `Path` can be used in a context where a `Term` is expected. For example:

```scala
Eql(tpe / "foo" / "bar", Const(42)) // implictly convert a Path to a Term[Int]
```

The root type and underlying schema will determine whether the resulting `Term` has list or unique semantics. This makes no difference for predicates that are eliminated by the database back-end, but the distinction remains important for in-memory mappings.