### PR TITLE
Add the context.path to the mapping error messages.

### DIFF
--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -75,7 +75,7 @@ abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
           else mkErrorResult(s"Expected Enum ${e.name}, found ${focus.noSpaces}")
         case _: ScalarType     if !focus.isObject => focus.rightIor // custom Scalar; any non-object type is fine
         case _ =>
-          mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus.noSpaces}")
+          mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus.noSpaces} at ${context.path.reverse.mkString("/")} ")
       }
 
     def preunique: Result[Cursor] = {

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -110,7 +110,7 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
             case (BooleanType, b: Boolean) => Json.fromBoolean(b).rightIor
             case (_: EnumType, e: Enumeration#Value) => Json.fromString(e.toString).rightIor
             case _ =>
-              mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus}")
+              mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus} at ${context.path.reverse.mkString("/")}")
           }
       }
 

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -210,7 +210,7 @@ abstract class AbstractCursor[T] extends Cursor {
   def isLeaf: Boolean = false
 
   def asLeaf: Result[Json] =
-    mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus}")
+    mkErrorResult(s"Expected Scalar type, found $tpe at ${context.path.reverse.mkString("/")}  for focus ${focus}")
 
   def preunique: Result[Cursor] =
     mkErrorResult(s"Expected List type, found $focus for ${tpe.nonNull.list}")


### PR DESCRIPTION
Add the `context.path` to the mapping error messages, so that it's easier to identify the field that's causing the error.

The error message is in no small part inspired by https://github.com/gemini-hlsw/gsp-graphql/pull/250