### PR TITLE
Reworked roots and added support for result transforms

### DIFF
--- a/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
+++ b/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
@@ -12,12 +12,12 @@ import edu.gemini.grackle.QueryInterpreter.{mkErrorResult, mkOneError}
 import edu.gemini.grackle.Value._
 import edu.gemini.grackle._
 import edu.gemini.grackle.generic._
-import edu.gemini.grackle.generic.semiauto._
 import edu.gemini.grackle.syntax._
 
 // The types and values for the in-memory Star Wars example.
 object StarWarsData {
-  import StarWarsMapping.{CharacterType, DroidType, HumanType}
+  import StarWarsMapping._
+  import semiauto._
 
   // #model_types
   object Episode extends Enumeration {
@@ -195,10 +195,10 @@ object StarWarsMapping extends GenericMapping[Id] {
         tpe = QueryType,
         fieldMappings =
           List(
-            GenericRoot("hero", characters),
-            GenericRoot("character", characters),
-            GenericRoot("human", characters.collect { case h: Human => h }),
-            GenericRoot("droid", characters.collect { case d: Droid => d })
+            GenericField("hero", characters),
+            GenericField("character", characters),
+            GenericField("human", characters.collect { case h: Human => h }),
+            GenericField("droid", characters.collect { case d: Droid => d })
           )
       )
       // #root

--- a/demo/src/main/scala/demo/world/WorldMapping.scala
+++ b/demo/src/main/scala/demo/world/WorldMapping.scala
@@ -110,13 +110,13 @@ trait WorldMapping[F[_]] extends DoobieMapping[F] {
       ObjectMapping(
         tpe = QueryType,
         fieldMappings = List(
-          SqlRoot("cities"),
-          SqlRoot("city"),
-          SqlRoot("country"),
-          SqlRoot("countries"),
-          SqlRoot("language"),
-          SqlRoot("search"),
-          SqlRoot("search2")
+          SqlObject("cities"),
+          SqlObject("city"),
+          SqlObject("country"),
+          SqlObject("countries"),
+          SqlObject("language"),
+          SqlObject("search"),
+          SqlObject("search2")
         )
       ),
       // #root

--- a/modules/circe/src/test/scala/CirceSpec.scala
+++ b/modules/circe/src/test/scala/CirceSpec.scala
@@ -288,4 +288,54 @@ final class CirceSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("hidden") {
+    val query = """
+      query {
+        root {
+          hidden
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unknown field 'hidden' in select"
+          }
+        ]
+      }
+    """
+
+    val res = TestCirceMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("computed") {
+    val query = """
+      query {
+        root {
+          computed
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "root" : {
+            "computed" : 14
+          }
+        }
+      }
+    """
+
+    val res = TestCirceMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
 }

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -8,63 +8,53 @@ import scala.reflect.ClassTag
 
 import cats.Monad
 import cats.implicits._
-import fs2.Stream
 import io.circe.Json
 import org.tpolecat.sourcepos.SourcePos
 
 import Cursor.{Context, Env}
-import QueryInterpreter.{mkErrorResult, mkOneError}
-import ScalarType._
+import QueryInterpreter.mkErrorResult
 
-abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
+abstract class ValueMapping[F[_]](implicit val M: Monad[F]) extends Mapping[F] with ValueMappingLike[F]
 
-  case class ValueRoot(otpe: Option[Type], fieldName: String, root: F[Any], mutation: Mutation)(
-    implicit val pos: SourcePos
-  ) extends RootMapping {
-    def cursor(query: Query, env: Env, resultName: Option[String]): Stream[F,Result[(Query, Cursor)]] = {
-      (for {
-        tpe      <- otpe
-        context0 <- Context(tpe, fieldName, resultName)
-      } yield {
-        val context = query match {
-          case _: Query.Unique => context0.asType(context0.tpe.nonNull.list)
-          case _ => context0
+trait ValueMappingLike[F[_]] extends Mapping[F] {
+  def valueCursor[T](tpe: Type, env: Env, t: T): Cursor =
+    ValueCursor(Context(tpe), t, None, env)
+
+  override def mkCursorForField(parent: Cursor, fieldName: String, resultName: Option[String]): Result[Cursor] = {
+    val context = parent.context
+    val fieldContext = context.forFieldOrAttribute(fieldName, resultName)
+    fieldMapping(context, fieldName) match {
+      case Some(ValueField(_, f, _)) =>
+        val parentFocus: Any = parent match {
+          case vc: ValueCursor => vc.focus
+          case _ => ()
         }
-        Stream.eval(root).map(r => Result((query, ValueCursor(context, r, None, env))))
-      }).getOrElse(mkErrorResult[(Query, Cursor)](s"Type ${otpe.getOrElse("unspecified type")} has no field '$fieldName'").pure[Stream[F,*]])
+        val childFocus = f.asInstanceOf[Any => Any](parentFocus)
+        if(isLeaf(fieldContext.tpe))
+          LeafCursor(fieldContext, childFocus, Some(parent), parent.env).rightIor
+        else
+          ValueCursor(fieldContext, childFocus, Some(parent), parent.env).rightIor
+
+      case _ =>
+        super.mkCursorForField(parent, fieldName, resultName)
     }
-
-    def withParent(tpe: Type): ValueRoot =
-      new ValueRoot(Some(tpe), fieldName, root, mutation)
   }
 
-  object ValueRoot {
-
-    // TODO: deprecate
-    def apply(fieldName: String, root: Any, mutation: Mutation = Mutation.None)(implicit pos: SourcePos): ValueRoot =
-      pure(fieldName, root, mutation)
-
-    /** Construct a `ValueRoot` with constant value `root`. */
-    def pure(fieldName: String, root: Any, mutation: Mutation = Mutation.None)(implicit pos: SourcePos): ValueRoot =
-      liftF(fieldName, root.pure[F], mutation)
-
-    /** Construct a `ValueRoot` with computed value `root`. */
-    def liftF(fieldName: String, root: F[Any], mutation: Mutation = Mutation.None)(implicit pos: SourcePos): ValueRoot =
-      new ValueRoot(None, fieldName, root, mutation)
-
-  }
-
-  sealed trait ValueField0[T] extends FieldMapping
-  object ValueField0 {
-    implicit def wrap[T](fm: FieldMapping): ValueField0[T] = Wrap(fm)
-    case class Wrap[T](fm: FieldMapping)(implicit val pos: SourcePos) extends ValueField0[T] {
+  sealed trait ValueFieldMapping[T] extends FieldMapping
+  object ValueFieldMapping {
+    implicit def wrap[T](fm: FieldMapping): ValueFieldMapping[T] = Wrap(fm)
+    case class Wrap[T](fm: FieldMapping)(implicit val pos: SourcePos) extends ValueFieldMapping[T] {
       def fieldName = fm.fieldName
       def hidden = fm.hidden
       def withParent(tpe: Type): FieldMapping = fm.withParent(tpe)
     }
   }
-  case class ValueField[T](fieldName: String, f: T => Any, hidden: Boolean = false)(implicit val pos: SourcePos) extends ValueField0[T] {
+  case class ValueField[T](fieldName: String, f: T => Any, hidden: Boolean = false)(implicit val pos: SourcePos) extends ValueFieldMapping[T] {
     def withParent(tpe: Type): ValueField[T] = this
+  }
+  object ValueField {
+    def fromValue[T](fieldName: String, t: T, hidden: Boolean = false)(implicit pos: SourcePos): ValueField[Unit] =
+      new ValueField[Unit](fieldName, _ => t, hidden)
   }
 
   case class ValueObjectMapping[T](
@@ -75,7 +65,7 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
 
   def ValueObjectMapping[T](
     tpe: Type,
-    fieldMappings: List[ValueField0[T]]
+    fieldMappings: List[ValueFieldMapping[T]]
   )(implicit classTag: ClassTag[T], pos: SourcePos): ValueObjectMapping[T] =
     new ValueObjectMapping(tpe, fieldMappings.map(_.withParent(tpe)), classTag)
 
@@ -90,29 +80,9 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
     def mkChild(context: Context = context, focus: Any = focus): ValueCursor =
       ValueCursor(context, focus, Some(this), Env.empty)
 
-    def isLeaf: Boolean =
-      tpe.dealias match {
-        case (_: ScalarType)|(_: EnumType) => true
-        case _ => leafMapping(tpe).isDefined
-      }
-
+    def isLeaf: Boolean = false
     def asLeaf: Result[Json] =
-      leafMapping(tpe) match {
-        case Some(mapping) => mapping.asInstanceOf[LeafMapping[Any]].encoder(focus).rightIor
-        case None =>
-          (tpe.dealias, focus) match {
-            case (StringType,  s: String)  => Json.fromString(s).rightIor
-            case (IDType,      s: String)  => Json.fromString(s).rightIor
-            case (IntType,     i: Int)     => Json.fromInt(i).rightIor
-            case (IntType,     l: Long)    => Json.fromLong(l).rightIor
-            case (FloatType,   f: Float)   => Json.fromFloat(f).toRightIor(mkOneError(s"Unrepresentable float %d"))
-            case (FloatType,   d: Double)  => Json.fromDouble(d).toRightIor(mkOneError(s"Unrepresentable double %d"))
-            case (BooleanType, b: Boolean) => Json.fromBoolean(b).rightIor
-            case (_: EnumType, e: Enumeration#Value) => Json.fromString(e.toString).rightIor
-            case _ =>
-              mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus} at ${context.path.reverse.mkString("/")}")
-          }
-      }
+      mkErrorResult(s"Not a leaf: $tpe")
 
     def preunique: Result[Cursor] = {
       val listTpe = tpe.nonNull.list
@@ -133,6 +103,11 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
       case _ => mkErrorResult(s"Expected List type, found $tpe")
     }
 
+    def listSize: Result[Int] = (tpe, focus) match {
+      case (ListType(_), it: List[_]) => it.size.rightIor
+      case _ => mkErrorResult(s"Expected List type, found $tpe")
+    }
+
     def isNullable: Boolean = (tpe, focus) match {
       case (_: NullableType, _: Option[_]) => true
       case _ => false
@@ -141,6 +116,11 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
     def asNullable: Result[Option[Cursor]] = (tpe, focus) match {
       case (NullableType(tpe), o: Option[_]) => o.map(f => mkChild(context.asType(tpe), f)).rightIor
       case (_: NullableType, _) => mkErrorResult(s"Found non-nullable $focus for $tpe")
+      case _ => mkErrorResult(s"Expected Nullable type, found $focus for $tpe")
+    }
+
+    def isDefined: Result[Boolean] = (tpe, focus) match {
+      case (_: NullableType, opt: Option[_]) => opt.isDefined.rightIor
       case _ => mkErrorResult(s"Expected Nullable type, found $focus for $tpe")
     }
 
@@ -162,16 +142,7 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
     def hasField(fieldName: String): Boolean =
       fieldMapping(context, fieldName).isDefined
 
-    def field(fieldName: String, resultName: Option[String]): Result[Cursor] = {
-      val fieldContext = context.forFieldOrAttribute(fieldName, resultName)
-      fieldMapping(context, fieldName) match {
-        case Some(ValueField(_, f, _)) =>
-          mkChild(fieldContext, f.asInstanceOf[Any => Any](focus)).rightIor
-        case Some(CursorField(_, f, _, _, _)) =>
-          f(this).map(res => mkChild(fieldContext, res))
-        case _ =>
-          mkErrorResult(s"No field '$fieldName' for type $tpe")
-      }
-    }
+    def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
+      mkCursorForField(this, fieldName, resultName)
   }
 }

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -3,7 +3,6 @@
 
 package compiler
 
-import cats.Id
 import cats.data.{Chain, Ior}
 import cats.implicits._
 import cats.tests.CatsSuite
@@ -393,7 +392,7 @@ final class CompilerSuite extends CatsSuite {
   }
 }
 
-object AtomicMapping extends Mapping[Id] {
+object AtomicMapping extends TestMapping {
   val schema =
     schema"""
       type Query {
@@ -409,8 +408,6 @@ object AtomicMapping extends Mapping[Id] {
   val QueryType = schema.ref("Query")
   val CharacterType = schema.ref("Character")
 
-  val typeMappings = Nil
-
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("character", List(Binding("id", StringValue(id))), child) =>
@@ -418,17 +415,15 @@ object AtomicMapping extends Mapping[Id] {
     }
   ))
 }
-
-trait DummyComponent extends Mapping[Id] {
+trait DummyComponent extends TestMapping {
   val schema = schema"type Query { dummy: Int }"
-  val typeMappings = Nil
 }
 
 object ComponentA extends DummyComponent
 object ComponentB extends DummyComponent
 object ComponentC extends DummyComponent
 
-object ComposedMapping extends Mapping[Id] {
+object ComposedMapping extends TestMapping {
   val schema =
     schema"""
       type Query {
@@ -457,7 +452,7 @@ object ComposedMapping extends Mapping[Id] {
   val FieldA2Type = schema.ref("FieldA2")
   val FieldB2Type = schema.ref("FieldB2")
 
-  val typeMappings =
+  override val typeMappings =
     List(
       ObjectMapping(
         tpe = QueryType,

--- a/modules/core/src/test/scala/compiler/Environment.scala
+++ b/modules/core/src/test/scala/compiler/Environment.scala
@@ -42,8 +42,8 @@ object EnvironmentMapping extends ValueMapping[Id] {
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("nested", ()),
-            ValueRoot("nestedSum", ())
+            ValueField[Unit]("nested", _ => ()),
+            ValueField[Unit]("nestedSum", _ => ())
           )
       ),
       ObjectMapping(

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -659,12 +659,12 @@ object FragmentMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("user", profiles.collect { case u: User => u }),
-            ValueRoot("profiles", profiles)
+            ValueField("user", _ => profiles.collect { case u: User => u }),
+            ValueField("profiles", _ => profiles)
           )
       ),
       ValueObjectMapping[Profile](

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -3,7 +3,6 @@
 
 package compiler
 
-import cats.Id
 import cats.data.{Chain, Ior}
 import cats.tests.CatsSuite
 
@@ -112,7 +111,7 @@ final class InputValuesSuite extends CatsSuite {
   }
 }
 
-object InputValuesMapping extends Mapping[Id] {
+object InputValuesMapping extends TestMapping {
   val schema =
     schema"""
       type Query {
@@ -133,8 +132,6 @@ object InputValuesMapping extends Mapping[Id] {
     """
 
   val QueryType = schema.ref("Query")
-
-  val typeMappings = Nil
 
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> PartialFunction.empty

--- a/modules/core/src/test/scala/compiler/Predicates.scala
+++ b/modules/core/src/test/scala/compiler/Predicates.scala
@@ -42,14 +42,14 @@ object ItemMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("itemByTag", items),
-            ValueRoot("itemByTagCount", items),
-            ValueRoot("itemByTagCountVA", items),
-            ValueRoot("itemByTagCountCA", items)
+            ValueField("itemByTag", _ => items),
+            ValueField("itemByTagCount", _ => items),
+            ValueField("itemByTagCountVA", _ => items),
+            ValueField("itemByTagCountCA", _ => items)
           )
       ),
       ValueObjectMapping[Item](

--- a/modules/core/src/test/scala/compiler/ScalarsSpec.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSpec.scala
@@ -127,16 +127,16 @@ object MovieMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("movieById", movies),
-            ValueRoot("moviesByGenre", movies),
-            ValueRoot("moviesReleasedBetween", movies),
-            ValueRoot("moviesLongerThan", movies),
-            ValueRoot("moviesShownLaterThan", movies),
-            ValueRoot("moviesShownBetween", movies)
+            ValueField("movieById", _ => movies),
+            ValueField("moviesByGenre", _ => movies),
+            ValueField("moviesReleasedBetween", _ => movies),
+            ValueField("moviesLongerThan", _ => movies),
+            ValueField("moviesShownLaterThan", _ => movies),
+            ValueField("moviesShownBetween", _ => movies)
           )
       ),
       ValueObjectMapping[Movie](

--- a/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
@@ -3,7 +3,6 @@
 
 package compiler
 
-import cats.Id
 import cats.data.Ior
 import cats.tests.CatsSuite
 
@@ -245,7 +244,7 @@ final class SkipIncludeSuite extends CatsSuite {
   }
 }
 
-object SkipIncludeMapping extends Mapping[Id] {
+object SkipIncludeMapping extends TestMapping {
   val schema =
     schema"""
       type Query {
@@ -256,6 +255,4 @@ object SkipIncludeMapping extends Mapping[Id] {
         subfieldB: String
       }
     """
-
-  val typeMappings = Nil
 }

--- a/modules/core/src/test/scala/compiler/TestMapping.scala
+++ b/modules/core/src/test/scala/compiler/TestMapping.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import cats.{Id, Monad}
+
+import edu.gemini.grackle._
+
+abstract class TestMapping(implicit val M: Monad[Id]) extends Mapping[Id] {
+  val typeMappings: List[TypeMapping] = Nil
+}

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -3,7 +3,6 @@
 
 package compiler
 
-import cats.Id
 import cats.data.{Chain, Ior}
 import cats.tests.CatsSuite
 
@@ -359,7 +358,7 @@ final class VariablesSuite extends CatsSuite {
   }
 }
 
-object VariablesMapping extends Mapping[Id] {
+object VariablesMapping extends TestMapping {
   val schema =
     schema"""
       type Query {
@@ -389,8 +388,6 @@ object VariablesMapping extends Mapping[Id] {
       scalar Date
       scalar BigDecimal
     """
-
-  val typeMappings = Nil
 
   val QueryType = schema.ref("Query")
 

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -45,11 +45,11 @@ object CurrencyMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("fx", currencies)
+            ValueField("fx", _ => currencies)
           )
       ),
       ValueObjectMapping[Currency](
@@ -106,12 +106,12 @@ object CountryMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("country", countries),
-            ValueRoot("countries", countries)
+            ValueField("country", _ => countries),
+            ValueField("countries", _ => countries)
           )
       ),
       ValueObjectMapping[Country](
@@ -136,7 +136,7 @@ object CountryMapping extends ValueMapping[Id] {
 
 /* Composition */
 
-object ComposedMapping extends Mapping[Id] {
+object ComposedMapping extends ComposedMapping[Id] {
   val schema =
     schema"""
       type Query {

--- a/modules/core/src/test/scala/composed/ComposedListSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedListSpec.scala
@@ -43,13 +43,13 @@ object CollectionMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("collection", collections.head),
-            ValueRoot("collections", collections),
-            ValueRoot("collectionByName", collections)
+            ValueField("collection", _ => collections.head),
+            ValueField("collections", _ => collections),
+            ValueField("collectionByName", _ => collections)
           )
       ),
       ValueObjectMapping[Collection](
@@ -94,11 +94,11 @@ object ItemMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("itemById", items)
+            ValueField("itemById", _ => items)
           )
       ),
       ValueObjectMapping[Item](
@@ -119,7 +119,7 @@ object ItemMapping extends ValueMapping[Id] {
   ))
 }
 
-object ComposedListMapping extends Mapping[Id] {
+object ComposedListMapping extends ComposedMapping[Id] {
   val schema =
     schema"""
       type Query {

--- a/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
@@ -1369,7 +1369,7 @@ final class IntrospectionSuite extends CatsSuite {
   }
 }
 
-object TestMapping extends Mapping[Id] {
+object TestMapping extends compiler.TestMapping {
   val schema =
     schema"""
       type Query {
@@ -1430,8 +1430,6 @@ object TestMapping extends Mapping[Id] {
         flags: Flags
       }
     """
-
-  val typeMappings = Nil
 }
 
 object SmallData {
@@ -1477,12 +1475,12 @@ object SmallMapping extends ValueMapping[Id] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("users", users),
-            ValueRoot("profiles", users)
+            ValueField("users", _ => users),
+            ValueField("profiles", _ => users)
           )
       ),
       ValueObjectMapping[User](

--- a/modules/core/src/test/scala/mapping/MappingValidatorSpec.scala
+++ b/modules/core/src/test/scala/mapping/MappingValidatorSpec.scala
@@ -4,20 +4,19 @@
 package validator
 
 import org.scalatest.funsuite.AnyFunSuite
-import edu.gemini.grackle.Mapping
-import cats.Id
 import cats.syntax.all._
 import edu.gemini.grackle.{ ListType, MappingValidator }
 import edu.gemini.grackle.MappingValidator.ValidationException
 import edu.gemini.grackle.syntax._
 
+import compiler.TestMapping
+
 final class ValidatorSpec extends AnyFunSuite {
 
   test("missing type mapping") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"type Foo { bar: String }"
-      val typeMappings = Nil
     }
 
     val es = M.validator.validateMapping()
@@ -30,9 +29,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("missing field mapping") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"type Foo { bar: String }"
-      val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
+      override val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
 
     val es = M.validator.validateMapping()
@@ -45,9 +44,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("inapplicable type (object mapping for scalar)") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"scalar Foo"
-      val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
+      override val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
 
     val es = M.validator.validateMapping()
@@ -60,9 +59,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("inapplicable type (leaf mapping for object)") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema =  schema"type Foo { bar: String }"
-      val typeMappings = List(LeafMapping[String](schema.ref("Foo")))
+      override val typeMappings = List(LeafMapping[String](schema.ref("Foo")))
     }
 
     val es = M.validator.validateMapping()
@@ -75,9 +74,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("enums are valid leaf mappings") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"enum Foo { BAR }"
-      val typeMappings = List(LeafMapping[String](schema.ref("Foo")))
+      override val typeMappings = List(LeafMapping[String](schema.ref("Foo")))
     }
 
     val es = M.validator.validateMapping()
@@ -90,9 +89,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("lists are valid leaf mappings") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"enum Foo { BAR } type Baz { quux: [Foo] }"
-      val typeMappings = List(
+      override val typeMappings = List(
         ObjectMapping(
           schema.ref("Baz"),
           List(
@@ -114,9 +113,8 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("input object types don't require mappings") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"input Foo { bar: String }"
-      val typeMappings = Nil
     }
 
     val es = M.validator.validateMapping()
@@ -129,9 +127,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("input only enums are valid primitive mappings") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"input Foo { bar: Bar } enum Bar { BAZ }"
-      val typeMappings = List(
+      override val typeMappings = List(
         PrimitiveMapping(schema.ref("Bar"))
       )
     }
@@ -147,9 +145,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("nonexistent type (type mapping)") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema""
-      val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
+      override val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
 
     val es = M.validator.validateMapping()
@@ -162,9 +160,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("unknown field") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"type Foo { bar: String }"
-      val typeMappings = List(
+      override val typeMappings = List(
         ObjectMapping(
           schema.ref("Foo"),
           List(
@@ -185,9 +183,9 @@ final class ValidatorSpec extends AnyFunSuite {
 
   test("non-field attributes are valid") {
 
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"type Foo { bar: String }"
-      val typeMappings = List(
+      override val typeMappings = List(
         ObjectMapping(
           schema.ref("Foo"),
           List(
@@ -207,9 +205,9 @@ final class ValidatorSpec extends AnyFunSuite {
   }
 
   test("unsafeValidate") {
-    object M extends Mapping[Id] {
+    object M extends TestMapping {
       val schema = schema"scalar Bar"
-      val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
+      override val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
     }
     intercept[ValidationException] {
       MappingValidator(M).unsafeValidate()

--- a/modules/doobie-pg/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie-pg/src/main/scala/DoobieMapping.scala
@@ -18,10 +18,18 @@ import org.tpolecat.typename.TypeName
 
 import edu.gemini.grackle.sql._
 
-abstract class DoobieMapping[F[_]: Sync](
+abstract class DoobieMapping[F[_]](
   val transactor: Transactor[F],
-  val monitor:    DoobieMonitor[F]
-) extends SqlMapping[F] {
+  val monitor:    DoobieMonitor[F],
+)(
+  implicit val M: Sync[F]
+) extends Mapping[F] with DoobieMappingLike[F]
+
+trait DoobieMappingLike[F[_]] extends Mapping[F] with SqlMappingLike[F] {
+  implicit val M: Sync[F]
+
+  def transactor: Transactor[F]
+  def monitor:    DoobieMonitor[F]
 
   type Codec   = (Meta[_], Boolean)
   type Encoder = (Put[_], Boolean)

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -65,6 +65,10 @@ final class LikeSpec extends DoobieDatabaseSuite with SqlLikeSpec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlLikeMapping[IO]
 }
 
+final class MixedSpec extends DoobieDatabaseSuite with SqlMixedSpec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlMixedMapping[IO]
+}
+
 final class MovieSpec extends DoobieDatabaseSuite with SqlMovieSpec {
   lazy val mapping =
     new DoobieTestMapping(xa) with SqlMovieMapping[IO] {
@@ -92,6 +96,18 @@ final class MutationSpec extends DoobieDatabaseSuite with SqlMutationSpec {
             .unique
             .transact(transactor)
     }
+}
+
+final class Paging1Spec extends DoobieDatabaseSuite with SqlPaging1Spec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlPaging1Mapping[IO]
+}
+
+final class Paging2Spec extends DoobieDatabaseSuite with SqlPaging2Spec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlPaging2Mapping[IO]
+}
+
+final class Paging3Spec extends DoobieDatabaseSuite with SqlPaging3Spec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlPaging3Mapping[IO]
 }
 
 final class ProjectionSpec extends DoobieDatabaseSuite with SqlProjectionSpec {

--- a/modules/generic/src/main/scala-3/genericmapping3.scala
+++ b/modules/generic/src/main/scala-3/genericmapping3.scala
@@ -7,107 +7,111 @@ package generic
 import cats.implicits._
 import shapeless3.deriving._
 
-import Cursor.{Context, Env}
+import Cursor.{AbstractCursor, Context, Env}
 import QueryInterpreter.{mkErrorResult, mkOneError}
 
-trait MkObjectCursorBuilder[T] {
-  def apply(tpe: Type): ObjectCursorBuilder[T]
-}
+trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: GenericMappingLike[F] =>
+  trait MkObjectCursorBuilder[T] {
+    def apply(tpe: Type): ObjectCursorBuilder[T]
+  }
 
-object MkObjectCursorBuilder {
-  type FieldMap[T] = Map[String, (Context, T, Option[Cursor], Env) => Result[Cursor]]
+  object MkObjectCursorBuilder {
+    type FieldMap[T] = Map[String, (Context, T, Option[Cursor], Env) => Result[Cursor]]
 
-  implicit def productCursorBuilder[T <: Product]
-    (implicit
-      inst:      K0.ProductInstances[CursorBuilder, T],
-      labelling: Labelling[T],
-    ): MkObjectCursorBuilder[T] =
-    new MkObjectCursorBuilder[T] {
-      def apply(tpe: Type): ObjectCursorBuilder[T] = {
-        def fieldMap: FieldMap[T] = {
-          labelling.elemLabels.zipWithIndex.map {
-            case (fieldName, idx) =>
-              def build(context: Context, focus: T, parent: Option[Cursor], env: Env) =
-                inst.project(focus)(idx)([t] => (builder: CursorBuilder[t], pt: t) => builder.build(context, pt, parent, env))
-              (fieldName, build _)
-          }.toMap
+    implicit def productCursorBuilder[T <: Product]
+      (implicit
+        inst:      K0.ProductInstances[CursorBuilder, T],
+        labelling: Labelling[T],
+      ): MkObjectCursorBuilder[T] =
+      new MkObjectCursorBuilder[T] {
+        def apply(tpe: Type): ObjectCursorBuilder[T] = {
+          def fieldMap: FieldMap[T] = {
+            labelling.elemLabels.zipWithIndex.map {
+              case (fieldName, idx) =>
+                def build(context: Context, focus: T, parent: Option[Cursor], env: Env) =
+                  inst.project(focus)(idx)([t] => (builder: CursorBuilder[t], pt: t) => builder.build(context, pt, parent, env))
+                (fieldName, build _)
+            }.toMap
+          }
+          new Impl[T](tpe, fieldMap)
         }
-        new Impl[T](tpe, fieldMap)
+      }
+
+    class Impl[T](tpe0: Type, fieldMap0: => FieldMap[T]) extends ObjectCursorBuilder[T] {
+      lazy val fieldMap = fieldMap0
+
+      val tpe = tpe0
+
+      def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+        CursorImpl(context.asType(tpe), focus, fieldMap, parent, env).rightIor
+
+      def renameField(from: String, to: String): ObjectCursorBuilder[T] =
+        transformFieldNames { case `from` => to ; case other => other }
+      def transformFieldNames(f: String => String): ObjectCursorBuilder[T] =
+        new Impl(tpe, fieldMap0.map { case (k, v) => (f(k), v) })
+      def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: => CursorBuilder[U]): ObjectCursorBuilder[T] = {
+        def build(context: Context, focus: T, parent: Option[Cursor], env: Env) =
+          f(focus).flatMap(f => cb.build(context, f, parent, env))
+
+        new Impl(tpe, fieldMap0.updated(fieldName, build _))
       }
     }
 
-  class Impl[T](tpe0: Type, fieldMap0: => FieldMap[T]) extends ObjectCursorBuilder[T] {
-    lazy val fieldMap = fieldMap0
+    case class CursorImpl[T](context: Context, focus: T, fieldMap: FieldMap[T], parent: Option[Cursor], env: Env)
+      extends AbstractCursor {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
-    val tpe = tpe0
+      override def hasField(fieldName: String): Boolean = fieldMap.contains(fieldName)
 
-    def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
-      CursorImpl(context.asType(tpe), focus, fieldMap, parent, env).rightIor
-
-    def renameField(from: String, to: String): ObjectCursorBuilder[T] =
-      transformFieldNames { case `from` => to ; case other => other }
-    def transformFieldNames(f: String => String): ObjectCursorBuilder[T] =
-      new Impl(tpe, fieldMap0.map { case (k, v) => (f(k), v) })
-    def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: => CursorBuilder[U]): ObjectCursorBuilder[T] = {
-      def build(context: Context, focus: T, parent: Option[Cursor], env: Env) =
-        f(focus).flatMap(f => cb.build(context, f, parent, env))
-
-      new Impl(tpe, fieldMap0.updated(fieldName, build _))
+      override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
+        mkCursorForField(this, fieldName, resultName) orElse {
+          fieldMap.get(fieldName).toRightIor(mkOneError(s"No field '$fieldName' for type $tpe")).flatMap { f =>
+            f(context.forFieldOrAttribute(fieldName, resultName), focus, Some(this), Env.empty)
+          }
+        }
     }
   }
 
-  case class CursorImpl[T](context: Context, focus: T, fieldMap: FieldMap[T], parent: Option[Cursor], env: Env)
-    extends AbstractCursor[Product] {
-    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+  trait MkInterfaceCursorBuilder[T] {
+    def apply(tpe: Type): CursorBuilder[T]
+  }
 
-    override def hasField(fieldName: String): Boolean = fieldMap.contains(fieldName)
+  object MkInterfaceCursorBuilder {
+    implicit def coproductCursorBuilder[T]
+      (implicit
+        inst: => K0.CoproductInstances[CursorBuilder, T]
+      ): MkInterfaceCursorBuilder[T] =
+      new MkInterfaceCursorBuilder[T] {
+        def apply(tpe: Type): CursorBuilder[T] = new Impl[T](tpe, inst)
+      }
 
-    override def field(fieldName: String, resultName: Option[String]): Result[Cursor] = {
-      fieldMap.get(fieldName).toRightIor(mkOneError(s"No field '$fieldName' for type $tpe")).flatMap { f =>
-        f(context.forFieldOrAttribute(fieldName, resultName), focus, Some(this), Env.empty)
+    class Impl[T](tpe0: Type, inst: K0.CoproductInstances[CursorBuilder, T]) extends CursorBuilder[T] {
+      val tpe = tpe0
+      def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] = {
+        inst.fold(focus)([t] => (builder: CursorBuilder[t], pt: t) =>
+          builder.build(context, pt, parent, env).map(cursor => CursorImpl(tpe, builder.tpe, cursor, parent, env))
+        )
       }
     }
-  }
-}
 
-trait MkInterfaceCursorBuilder[T] {
-  def apply(tpe: Type): CursorBuilder[T]
-}
+    case class CursorImpl[T](tpe0: Type, rtpe: Type, cursor: Cursor, parent: Option[Cursor], env: Env)
+      extends AbstractCursor {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
-object MkInterfaceCursorBuilder {
-  implicit def coproductCursorBuilder[T]
-    (implicit
-      inst: => K0.CoproductInstances[CursorBuilder, T]
-    ): MkInterfaceCursorBuilder[T] =
-    new MkInterfaceCursorBuilder[T] {
-      def apply(tpe: Type): CursorBuilder[T] = new Impl[T](tpe, inst)
+      def focus: Any = cursor.focus
+      val context: Context = cursor.context.asType(tpe0)
+
+      override def hasField(fieldName: String): Boolean = cursor.hasField(fieldName)
+
+      override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
+        mkCursorForField(this, fieldName, resultName) orElse cursor.field(fieldName, resultName)
+
+      override def narrowsTo(subtpe: TypeRef): Boolean =
+        subtpe <:< tpe && rtpe <:< subtpe
+
+      override def narrow(subtpe: TypeRef): Result[Cursor] =
+        if (narrowsTo(subtpe)) copy(tpe0 = subtpe).rightIor
+        else mkErrorResult(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
     }
-
-  class Impl[T](tpe0: Type, inst: K0.CoproductInstances[CursorBuilder, T]) extends CursorBuilder[T] {
-    val tpe = tpe0
-    def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] = {
-      inst.fold(focus)([t] => (builder: CursorBuilder[t], pt: t) =>
-        builder.build(context, pt, parent, env).map(cursor => CursorImpl(tpe, builder.tpe, cursor, parent, env))
-      )
-    }
-  }
-
-  case class CursorImpl[T](tpe0: Type, rtpe: Type, cursor: Cursor, parent: Option[Cursor], env: Env)
-    extends AbstractCursor[T] {
-    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
-    def focus: Any = cursor.focus
-    val context: Context = cursor.context.asType(tpe0)
-
-    override def hasField(fieldName: String): Boolean = cursor.hasField(fieldName)
-
-    override def field(fieldName: String, resultName: Option[String]): Result[Cursor] = cursor.field(fieldName, resultName)
-
-    override def narrowsTo(subtpe: TypeRef): Boolean =
-      subtpe <:< tpe && rtpe <:< subtpe
-
-    override def narrow(subtpe: TypeRef): Result[Cursor] =
-      if (narrowsTo(subtpe)) copy(tpe0 = subtpe).rightIor
-      else mkErrorResult(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
   }
 }

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -8,235 +8,210 @@ import scala.collection.Factory
 
 import cats.Monad
 import cats.implicits._
-import fs2.Stream
 import io.circe.{Encoder, Json}
 import org.tpolecat.sourcepos.SourcePos
 
-import Cursor.{Context, Env}
-import QueryInterpreter.{mkErrorResult, mkOneError}
+import Cursor.{AbstractCursor, Context, Env}
+import QueryInterpreter.mkOneError
 
-abstract class GenericMapping[F[_]: Monad] extends Mapping[F] {
-  case class GenericRoot[T](val tpe: Option[Type], val fieldName: String, t: T, cb: () => CursorBuilder[T], mutation: Mutation)(
+abstract class GenericMapping[F[_]](implicit val M: Monad[F]) extends Mapping[F] with GenericMappingLike[F]
+
+trait GenericMappingLike[F[_]] extends ScalaVersionSpecificGenericMappingLike[F] {
+  def genericCursor[T](tpe: Type, env: Env, t: T)(implicit cb: => CursorBuilder[T]): Result[Cursor] =
+    cb.build(Context(tpe), t, None, env)
+
+  override def mkCursorForField(parent: Cursor, fieldName: String, resultName: Option[String]): Result[Cursor] = {
+    val context = parent.context
+    val fieldContext = context.forFieldOrAttribute(fieldName, resultName)
+    fieldMapping(context, fieldName) match {
+      case Some(GenericField(_, _, t, cb, _)) =>
+        cb().build(fieldContext, t, Some(parent), parent.env)
+      case _ =>
+        super.mkCursorForField(parent, fieldName, resultName)
+    }
+  }
+
+  case class GenericField[T](val tpe: Option[Type], val fieldName: String, t: T, cb: () => CursorBuilder[T], hidden: Boolean)(
     implicit val pos: SourcePos
-  ) extends RootMapping {
-    lazy val cursorBuilder = cb()
-    def cursor(query: Query, env: Env, resultName: Option[String]): Stream[F,Result[(Query, Cursor)]] = {
-      val c =
-        for {
-          tpe0    <- tpe.toRightIor(mkOneError("Undefined root type"))
-          context <- Context(tpe0, fieldName, resultName).toRightIor(mkOneError("Unable to construct root context"))
-          c       <- cursorBuilder.build(context, t, None, env)
-        } yield c
-      c.tupleLeft(query).pure[Stream[F,*]]
-    }
-    def withParent(tpe: Type): GenericRoot[T] =
-      new GenericRoot(Some(tpe), fieldName, t, cb, mutation)
+  ) extends FieldMapping {
+    def withParent(tpe: Type): GenericField[T] =
+      new GenericField(Some(tpe), fieldName, t, cb, hidden)
   }
 
-  def GenericRoot[T](fieldName: String, t: T, mutation: Mutation = Mutation.None)(implicit cb: => CursorBuilder[T]): GenericRoot[T] =
-    new GenericRoot(None, fieldName, t, () => cb, mutation)
-}
+  def GenericField[T](fieldName: String, t: T, hidden: Boolean = true)(implicit cb: => CursorBuilder[T], pos: SourcePos): GenericField[T] =
+    new GenericField(None, fieldName, t, () => cb, hidden)
 
-object semiauto {
-  final def deriveObjectCursorBuilder[T](tpe: Type)
-    (implicit mkBuilder: => MkObjectCursorBuilder[T]): ObjectCursorBuilder[T] = mkBuilder(tpe)
-  final def deriveInterfaceCursorBuilder[T](tpe: Type)
-    (implicit mkBuilder: => MkInterfaceCursorBuilder[T]): CursorBuilder[T] = mkBuilder(tpe)
-}
-
-trait ObjectCursorBuilder[T] extends CursorBuilder[T] {
-  def renameField(from: String, to: String): ObjectCursorBuilder[T]
-  def transformFieldNames(f: String => String): ObjectCursorBuilder[T]
-  def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: => CursorBuilder[U]): ObjectCursorBuilder[T]
-}
-
-trait CursorBuilder[T] { outer =>
-  def tpe: Type
-  def build(context: Context, focus: T, parent: Option[Cursor] = None, env: Env = Env.empty): Result[Cursor]
-}
-
-object CursorBuilder {
-  def apply[T](implicit cb: CursorBuilder[T]): CursorBuilder[T] = cb
-
-  import ScalarType._
-
-  implicit val stringCursorBuilder: CursorBuilder[String] = {
-    case class StringCursor(context: Context, focus: String, parent: Option[Cursor], env: Env) extends PrimitiveCursor[String] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] = Json.fromString(focus).rightIor
-    }
-    new CursorBuilder[String] {
-      val tpe = StringType
-      def build(context: Context, focus: String, parent: Option[Cursor], env: Env): Result[Cursor] =
-        StringCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
+  object semiauto {
+    final def deriveObjectCursorBuilder[T](tpe: Type)
+      (implicit mkBuilder: => MkObjectCursorBuilder[T]): ObjectCursorBuilder[T] = mkBuilder(tpe)
+    final def deriveInterfaceCursorBuilder[T](tpe: Type)
+      (implicit mkBuilder: => MkInterfaceCursorBuilder[T]): CursorBuilder[T] = mkBuilder(tpe)
   }
 
-  implicit val intCursorBuilder: CursorBuilder[Int] = {
-    case class IntCursor(context: Context, focus: Int, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Int] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] = Json.fromInt(focus).rightIor
-    }
-    new CursorBuilder[Int] {
-      val tpe = IntType
-      def build(context: Context, focus: Int, parent: Option[Cursor], env: Env): Result[Cursor] =
-        IntCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
+  trait ObjectCursorBuilder[T] extends CursorBuilder[T] {
+    def renameField(from: String, to: String): ObjectCursorBuilder[T]
+    def transformFieldNames(f: String => String): ObjectCursorBuilder[T]
+    def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: => CursorBuilder[U]): ObjectCursorBuilder[T]
   }
 
-  implicit val longCursorBuilder: CursorBuilder[Long] = {
-    case class LongCursor(context: Context, focus: Long, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Long] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] = Json.fromLong(focus).rightIor
-    }
-    new CursorBuilder[Long] {
-      val tpe = IntType
-      def build(context: Context, focus: Long, parent: Option[Cursor], env: Env): Result[Cursor] =
-        LongCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
+  trait CursorBuilder[T] { outer =>
+    def tpe: Type
+    def build(context: Context, focus: T, parent: Option[Cursor] = None, env: Env = Env.empty): Result[Cursor]
   }
 
-  implicit val floatCursorBuilder: CursorBuilder[Float] = {
-    case class FloatCursor(context: Context, focus: Float, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Float] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] =
-        Json.fromFloat(focus).toRightIor(mkOneError(s"Unrepresentable float %focus"))
-    }
-    new CursorBuilder[Float] {
-      val tpe = FloatType
-      def build(context: Context, focus: Float, parent: Option[Cursor], env: Env): Result[Cursor] =
-        FloatCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
-  }
+  object CursorBuilder {
+    def apply[T](implicit cb: CursorBuilder[T]): CursorBuilder[T] = cb
 
-  implicit val doubleCursorBuilder: CursorBuilder[Double] = {
-    case class DoubleCursor(context: Context, focus: Double, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Double] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] =
-        Json.fromDouble(focus).toRightIor(mkOneError(s"Unrepresentable double %focus"))
-    }
-    new CursorBuilder[Double] {
-      val tpe = FloatType
-      def build(context: Context, focus: Double, parent: Option[Cursor], env: Env): Result[Cursor] =
-        DoubleCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
-  }
+    import ScalarType._
 
-  implicit val booleanCursorBuilder: CursorBuilder[Boolean] = {
-    case class BooleanCursor(context: Context, focus: Boolean, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Boolean] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] = Json.fromBoolean(focus).rightIor
-    }
-    new CursorBuilder[Boolean] {
-      val tpe = BooleanType
-      def build(context: Context, focus: Boolean, parent: Option[Cursor], env: Env): Result[Cursor] =
-        BooleanCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
-  }
-
-  def deriveEnumerationCursorBuilder[T <: Enumeration#Value](tpe0: Type): CursorBuilder[T] = {
-    case class EnumerationCursor(context: Context, focus: T, parent: Option[Cursor], env: Env) extends PrimitiveCursor[T] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-      override def asLeaf: Result[Json] = Json.fromString(focus.toString).rightIor
-    }
-    new CursorBuilder[T] {
-      val tpe = tpe0
-      def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
-        EnumerationCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
-  }
-
-  implicit def enumerationCursorBuilder[T <: Enumeration#Value]: CursorBuilder[T] =
-    deriveEnumerationCursorBuilder(StringType)
-
-  implicit def optionCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[Option[T]] = {
-    case class OptionCursor(context: Context, focus: Option[T], parent: Option[Cursor], env: Env) extends AbstractCursor[Option[T]] {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
-      override def isNullable: Boolean = true
-      override def asNullable: Result[Option[Cursor]] = {
-        focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env))
+    implicit val stringCursorBuilder: CursorBuilder[String] = {
+      case class StringCursor(context: Context, focus: String, parent: Option[Cursor], env: Env) extends PrimitiveCursor[String] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] = Json.fromString(focus).rightIor
+      }
+      new CursorBuilder[String] {
+        val tpe = StringType
+        def build(context: Context, focus: String, parent: Option[Cursor], env: Env): Result[Cursor] =
+          StringCursor(context.asType(tpe), focus, parent, env).rightIor
       }
     }
 
-    new CursorBuilder[Option[T]] { outer =>
-      val tpe = NullableType(elemBuilder.tpe)
-      def build(context: Context, focus: Option[T], parent: Option[Cursor], env: Env): Result[Cursor] =
-        OptionCursor(context.asType(tpe), focus, parent, env).rightIor
+    implicit val intCursorBuilder: CursorBuilder[Int] = {
+      case class IntCursor(context: Context, focus: Int, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Int] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] = Json.fromInt(focus).rightIor
+      }
+      new CursorBuilder[Int] {
+        val tpe = IntType
+        def build(context: Context, focus: Int, parent: Option[Cursor], env: Env): Result[Cursor] =
+          IntCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
     }
-  }
 
-  implicit def listCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[List[T]] = {
-    case class ListCursor(context: Context, focus: List[T], parent: Option[Cursor], env: Env) extends AbstractCursor[List[T]] {
+    implicit val longCursorBuilder: CursorBuilder[Long] = {
+      case class LongCursor(context: Context, focus: Long, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Long] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] = Json.fromLong(focus).rightIor
+      }
+      new CursorBuilder[Long] {
+        val tpe = IntType
+        def build(context: Context, focus: Long, parent: Option[Cursor], env: Env): Result[Cursor] =
+          LongCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    implicit val floatCursorBuilder: CursorBuilder[Float] = {
+      case class FloatCursor(context: Context, focus: Float, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Float] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] =
+          Json.fromFloat(focus).toRightIor(mkOneError(s"Unrepresentable float %focus"))
+      }
+      new CursorBuilder[Float] {
+        val tpe = FloatType
+        def build(context: Context, focus: Float, parent: Option[Cursor], env: Env): Result[Cursor] =
+          FloatCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    implicit val doubleCursorBuilder: CursorBuilder[Double] = {
+      case class DoubleCursor(context: Context, focus: Double, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Double] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] =
+          Json.fromDouble(focus).toRightIor(mkOneError(s"Unrepresentable double %focus"))
+      }
+      new CursorBuilder[Double] {
+        val tpe = FloatType
+        def build(context: Context, focus: Double, parent: Option[Cursor], env: Env): Result[Cursor] =
+          DoubleCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    implicit val booleanCursorBuilder: CursorBuilder[Boolean] = {
+      case class BooleanCursor(context: Context, focus: Boolean, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Boolean] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] = Json.fromBoolean(focus).rightIor
+      }
+      new CursorBuilder[Boolean] {
+        val tpe = BooleanType
+        def build(context: Context, focus: Boolean, parent: Option[Cursor], env: Env): Result[Cursor] =
+          BooleanCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    def deriveEnumerationCursorBuilder[T <: Enumeration#Value](tpe0: Type): CursorBuilder[T] = {
+      case class EnumerationCursor(context: Context, focus: T, parent: Option[Cursor], env: Env) extends PrimitiveCursor[T] {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+        override def asLeaf: Result[Json] = Json.fromString(focus.toString).rightIor
+      }
+      new CursorBuilder[T] {
+        val tpe = tpe0
+        def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+          EnumerationCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    implicit def enumerationCursorBuilder[T <: Enumeration#Value]: CursorBuilder[T] =
+      deriveEnumerationCursorBuilder(StringType)
+
+    implicit def optionCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[Option[T]] = {
+      case class OptionCursor(context: Context, focus: Option[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+        override def isNullable: Boolean = true
+        override def asNullable: Result[Option[Cursor]] = {
+          focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env))
+        }
+      }
+
+      new CursorBuilder[Option[T]] { outer =>
+        val tpe = NullableType(elemBuilder.tpe)
+        def build(context: Context, focus: Option[T], parent: Option[Cursor], env: Env): Result[Cursor] =
+          OptionCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    implicit def listCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[List[T]] = {
+      case class ListCursor(context: Context, focus: List[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
+        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+        override def preunique: Result[Cursor] = {
+          val listTpe = tpe.nonNull.list
+          copy(context = context.asType(listTpe)).rightIor
+        }
+
+        override def isList: Boolean = true
+        override def asList[C](factory: Factory[Cursor, C]): Result[C] = {
+          focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env)).map(_.to(factory))
+        }
+      }
+
+      new CursorBuilder[List[T]] { outer =>
+        val tpe = ListType(elemBuilder.tpe)
+        def build(context: Context, focus: List[T], parent: Option[Cursor], env: Env): Result[Cursor] =
+          ListCursor(context.asType(tpe), focus, parent, env).rightIor
+      }
+    }
+
+    case class LeafCursor[T](context: Context, focus: T, encoder: Encoder[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
       def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
-      override def preunique: Result[Cursor] = {
-        val listTpe = tpe.nonNull.list
-        copy(context = context.asType(listTpe)).rightIor
-      }
-
-      override def isList: Boolean = true
-      override def asList[C](factory: Factory[Cursor, C]): Result[C] = {
-        focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env)).map(_.to(factory))
-      }
+      override def isLeaf: Boolean = true
+      override def asLeaf: Result[Json] = encoder(focus).rightIor
     }
 
-    new CursorBuilder[List[T]] { outer =>
-      val tpe = ListType(elemBuilder.tpe)
-      def build(context: Context, focus: List[T], parent: Option[Cursor], env: Env): Result[Cursor] =
-        ListCursor(context.asType(tpe), focus, parent, env).rightIor
-    }
+    def deriveLeafCursorBuilder[T](tpe0: Type)(implicit encoder: Encoder[T]): CursorBuilder[T] =
+      new CursorBuilder[T] {
+        val tpe = tpe0
+        def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+          new LeafCursor(context.asType(tpe), focus, encoder, parent, env).rightIor
+      }
+
+    implicit def leafCursorBuilder[T](implicit encoder: Encoder[T]): CursorBuilder[T] =
+      deriveLeafCursorBuilder(StringType)
   }
 
-  case class LeafCursor[T](context: Context, focus: T, encoder: Encoder[T], parent: Option[Cursor], env: Env) extends AbstractCursor[T] {
-    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
+  abstract class PrimitiveCursor[T] extends AbstractCursor {
+    val focus: T
     override def isLeaf: Boolean = true
-    override def asLeaf: Result[Json] = encoder(focus).rightIor
   }
-
-  def deriveLeafCursorBuilder[T](tpe0: Type)(implicit encoder: Encoder[T]): CursorBuilder[T] =
-    new CursorBuilder[T] {
-      val tpe = tpe0
-      def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
-        new LeafCursor(context.asType(tpe), focus, encoder, parent, env).rightIor
-    }
-
-  implicit def leafCursorBuilder[T](implicit encoder: Encoder[T]): CursorBuilder[T] =
-    deriveLeafCursorBuilder(StringType)
-}
-
-abstract class AbstractCursor[T] extends Cursor {
-  def isLeaf: Boolean = false
-
-  def asLeaf: Result[Json] =
-    mkErrorResult(s"Expected Scalar type, found $tpe at ${context.path.reverse.mkString("/")}  for focus ${focus}")
-
-  def preunique: Result[Cursor] =
-    mkErrorResult(s"Expected List type, found $focus for ${tpe.nonNull.list}")
-
-  def isList: Boolean = false
-
-  def asList[C](factory: Factory[Cursor, C]): Result[C] =
-    mkErrorResult(s"Expected List type, found $tpe")
-
-  def isNullable: Boolean = false
-
-  def asNullable: Result[Option[Cursor]] =
-    mkErrorResult(s"Expected Nullable type, found $focus for $tpe")
-
-  def narrowsTo(subtpe: TypeRef): Boolean = false
-
-  def narrow(subtpe: TypeRef): Result[Cursor] =
-    mkErrorResult(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
-
-  def hasField(fieldName: String): Boolean = false
-
-  def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
-    mkErrorResult(s"No field '$fieldName' for type $tpe")
-}
-
-abstract class PrimitiveCursor[T] extends AbstractCursor[T] {
-  val focus: T
-  override def isLeaf: Boolean = true
 }

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -18,10 +18,10 @@ import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ScalarType._
-import semiauto._
 
 object StarWarsData {
-  import StarWarsMapping.{CharacterType, DroidType, HumanType}
+  import StarWarsMapping._
+  import semiauto._
 
   object Episode extends Enumeration {
     val NEWHOPE, EMPIRE, JEDI = Value
@@ -192,10 +192,10 @@ object StarWarsMapping extends GenericMapping[Id] {
         tpe = QueryType,
         fieldMappings =
           List(
-            GenericRoot("hero", characters),
-            GenericRoot("character", characters),
-            GenericRoot("human", characters.collect { case h: Human => h }),
-            GenericRoot("droid", characters.collect { case d: Droid => d })
+            GenericField("hero", characters),
+            GenericField("character", characters),
+            GenericField("human", characters.collect { case h: Human => h }),
+            GenericField("droid", characters.collect { case d: Droid => d })
           )
       )
     )

--- a/modules/generic/src/test/scala/recursion.scala
+++ b/modules/generic/src/test/scala/recursion.scala
@@ -12,10 +12,10 @@ import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import QueryInterpreter.mkOneError
-import semiauto._
 
 object MutualRecursionData {
   import MutualRecursionMapping._
+  import semiauto._
 
   case class Programme(id: String, productions: Option[List[String]])
   object Programme {
@@ -76,8 +76,8 @@ object MutualRecursionMapping extends GenericMapping[Id] {
         tpe = QueryType,
         fieldMappings =
           List(
-            GenericRoot("programmeById", programmes),
-            GenericRoot("productionById", productions)
+            GenericField("programmeById", programmes),
+            GenericField("productionById", productions)
           )
       )
     )

--- a/modules/generic/src/test/scala/scalars.scala
+++ b/modules/generic/src/test/scala/scalars.scala
@@ -16,10 +16,10 @@ import io.circe.Encoder
 import edu.gemini.grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
-import semiauto._
 
 object MovieData {
   import MovieMapping._
+  import semiauto._
 
   sealed trait Genre extends Product with Serializable
   object Genre {
@@ -136,12 +136,12 @@ object MovieMapping extends GenericMapping[Id] {
         tpe = QueryType,
         fieldMappings =
           List(
-            GenericRoot("movieById", movies),
-            GenericRoot("moviesByGenre", movies),
-            GenericRoot("moviesReleasedBetween", movies),
-            GenericRoot("moviesLongerThan", movies),
-            GenericRoot("moviesShownLaterThan", movies),
-            GenericRoot("moviesShownBetween", movies)
+            GenericField("movieById", movies),
+            GenericField("moviesByGenre", movies),
+            GenericField("moviesReleasedBetween", movies),
+            GenericField("moviesLongerThan", movies),
+            GenericField("moviesShownLaterThan", movies),
+            GenericField("moviesShownBetween", movies)
           )
       )
     )

--- a/modules/skunk/src/main/scala/SkunkMapping.scala
+++ b/modules/skunk/src/main/scala/SkunkMapping.scala
@@ -18,10 +18,18 @@ import org.tpolecat.typename.TypeName
 
 import edu.gemini.grackle.sql._
 
-abstract class SkunkMapping[F[_]: Sync](
+abstract class SkunkMapping[F[_]](
   val pool:    Resource[F, Session[F]],
   val monitor: SkunkMonitor[F]
-) extends SqlMapping[F] { outer =>
+)(
+  implicit val M: Sync[F]
+) extends Mapping[F] with SkunkMappingLike[F]
+
+trait SkunkMappingLike[F[_]] extends Mapping[F] with SqlMappingLike[F] { outer =>
+  implicit val M: Sync[F]
+
+  val pool:    Resource[F, Session[F]]
+  val monitor: SkunkMonitor[F]
 
   // Grackle needs to know about codecs, encoders, and fragments.
   type Codec    = (_root_.skunk.Codec[_], Boolean)

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -65,6 +65,10 @@ final class LikeSpec extends SkunkDatabaseSuite with SqlLikeSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlLikeMapping[IO]
 }
 
+final class MixedSpec extends SkunkDatabaseSuite with SqlMixedSpec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlMixedMapping[IO]
+}
+
 final class MovieSpec extends SkunkDatabaseSuite with SqlMovieSpec {
   lazy val mapping =
     new SkunkTestMapping(pool) with SqlMovieMapping[IO] {
@@ -95,6 +99,18 @@ final class MutationSpec extends SkunkDatabaseSuite with SqlMutationSpec {
           }
         }
     }
+}
+
+final class Paging1Spec extends SkunkDatabaseSuite with SqlPaging1Spec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlPaging1Mapping[IO]
+}
+
+final class Paging2Spec extends SkunkDatabaseSuite with SqlPaging2Spec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlPaging2Mapping[IO]
+}
+
+final class Paging3Spec extends SkunkDatabaseSuite with SqlPaging3Spec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlPaging3Mapping[IO]
 }
 
 final class ProjectionSpec extends SkunkDatabaseSuite with SqlProjectionSpec {

--- a/modules/sql/src/main/scala/SqlMappingValidator.scala
+++ b/modules/sql/src/main/scala/SqlMappingValidator.scala
@@ -10,7 +10,7 @@ import org.tpolecat.typename.typeName
 trait SqlMappingValidator extends MappingValidator {
 
   type F[_]
-  type M <: SqlMapping[F]
+  type M <: SqlMappingLike[F]
 
   val mapping: M
 
@@ -89,10 +89,10 @@ trait SqlMappingValidator extends MappingValidator {
 
 object SqlMappingValidator {
 
-  def apply[G[_]](m: SqlMapping[G]): SqlMappingValidator =
+  def apply[G[_]](m: SqlMappingLike[G]): SqlMappingValidator =
     new SqlMappingValidator {
       type F[a] = G[a]
-      type M = SqlMapping[F]
+      type M = SqlMappingLike[F]
       val mapping = m
     }
 

--- a/modules/sql/src/test/scala/SqlArrayJoinMapping.scala
+++ b/modules/sql/src/test/scala/SqlArrayJoinMapping.scala
@@ -54,7 +54,7 @@ trait SqlArrayJoinMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("root")
+            SqlObject("root")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlCoalesceMapping.scala
+++ b/modules/sql/src/test/scala/SqlCoalesceMapping.scala
@@ -54,7 +54,7 @@ trait SqlCoalesceMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("r")
+            SqlObject("r")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlComposedWorldMapping.scala
+++ b/modules/sql/src/test/scala/SqlComposedWorldMapping.scala
@@ -53,11 +53,11 @@ class CurrencyMapping[F[_] : Monad] extends ValueMapping[F] {
 
   val typeMappings =
     List(
-      ObjectMapping(
+      ValueObjectMapping[Unit](
         tpe = QueryType,
         fieldMappings =
           List(
-            ValueRoot("allCurrencies", currencies)
+            ValueField("allCurrencies", _ => currencies)
           )
       ),
       ValueObjectMapping[Currency](
@@ -79,7 +79,7 @@ object CurrencyMapping {
 /* Composition */
 
 class SqlComposedMapping[F[_] : Monad]
-  (world: Mapping[F], currency: Mapping[F]) extends Mapping[F] {
+  (world: Mapping[F], currency: Mapping[F]) extends ComposedMapping[F] {
   val schema =
     schema"""
       type Query {

--- a/modules/sql/src/test/scala/SqlCursorJsonMapping.scala
+++ b/modules/sql/src/test/scala/SqlCursorJsonMapping.scala
@@ -74,7 +74,7 @@ trait SqlCursorJsonMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("brands")
+            SqlObject("brands")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlEmbeddingMapping.scala
+++ b/modules/sql/src/test/scala/SqlEmbeddingMapping.scala
@@ -64,8 +64,8 @@ trait SqlEmbeddingMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("films"),
-            SqlRoot("series")
+            SqlObject("films"),
+            SqlObject("series")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlFilterOrderOffsetLimit2Mapping.scala
+++ b/modules/sql/src/test/scala/SqlFilterOrderOffsetLimit2Mapping.scala
@@ -69,8 +69,8 @@ trait SqlFilterOrderOffsetLimit2Mapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("root"),
-            SqlRoot("containers")
+            SqlObject("root"),
+            SqlObject("containers")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlFilterOrderOffsetLimitMapping.scala
+++ b/modules/sql/src/test/scala/SqlFilterOrderOffsetLimitMapping.scala
@@ -88,7 +88,7 @@ trait SqlFilterOrderOffsetLimitMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("root")
+            SqlObject("root")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlGraphMapping.scala
+++ b/modules/sql/src/test/scala/SqlGraphMapping.scala
@@ -48,7 +48,7 @@ trait SqlGraphMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("node")
+            SqlObject("node")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlInterfacesMapping.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesMapping.scala
@@ -95,8 +95,8 @@ trait SqlInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("entities"),
-            SqlRoot("films"),
+            SqlObject("entities"),
+            SqlObject("films"),
           )
       ),
       SqlInterfaceMapping(

--- a/modules/sql/src/test/scala/SqlJsonbMapping.scala
+++ b/modules/sql/src/test/scala/SqlJsonbMapping.scala
@@ -70,8 +70,8 @@ trait SqlJsonbMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("record"),
-            SqlRoot("records")
+            SqlObject("record"),
+            SqlObject("records")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlLikeMapping.scala
+++ b/modules/sql/src/test/scala/SqlLikeMapping.scala
@@ -44,7 +44,7 @@ trait SqlLikeMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("likes"),
+            SqlObject("likes"),
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlMixedMapping.scala
+++ b/modules/sql/src/test/scala/SqlMixedMapping.scala
@@ -1,0 +1,95 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import java.util.UUID
+
+import scala.util.Try
+
+import cats.implicits._
+
+import edu.gemini.grackle._
+import syntax._
+import Query._
+import Predicate._
+import Value._
+import QueryCompiler._
+
+// Mapping illustrating arbitrary mapping mixins with root query fields
+// defined by sql, value and circe mappings.
+trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] { self =>
+  object movies extends TableDef("movies") {
+    val id = col("id", uuid)
+    val title = col("title", text)
+  }
+
+  val schema =
+    schema"""
+        type Query {
+          movie(id: UUID!): Movie
+          foo: Foo!
+          bar: Bar
+        }
+        type Movie {
+          id: UUID!
+          title: String!
+        }
+        type Foo {
+          value: Int!
+        }
+        type Bar {
+          message: String
+        }
+        scalar UUID
+      """
+
+  val QueryType = schema.ref("Query")
+  val MovieType = schema.ref("Movie")
+  val FooType = schema.ref("Foo")
+  val BarType = schema.ref("Bar")
+  val UUIDType = schema.ref("UUID")
+
+  case class Foo(value: Int)
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlObject("movie"),
+            ValueField[Unit]("foo", _ => Foo(23)),
+            CirceField("bar", json"""{ "message": "Hello world" }""")
+          )
+      ),
+      ObjectMapping(
+        tpe = MovieType,
+        fieldMappings =
+          List(
+            SqlField("id", movies.id, key = true),
+            SqlField("title", movies.title),
+          )
+      ),
+      ValueObjectMapping[Foo](
+        tpe = FooType,
+        fieldMappings =
+          List(
+            ValueField("value", _.value)
+          )
+      ),
+      LeafMapping[UUID](UUIDType)
+    )
+
+  object UUIDValue {
+    def unapply(s: StringValue): Option[UUID] =
+      Try(UUID.fromString(s.value)).toOption
+  }
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("movie", List(Binding("id", UUIDValue(id))), child) =>
+        Select("movie", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).rightIor
+    }
+  ))
+}

--- a/modules/sql/src/test/scala/SqlMovieMapping.scala
+++ b/modules/sql/src/test/scala/SqlMovieMapping.scala
@@ -94,14 +94,14 @@ trait SqlMovieMapping[F[_]] extends SqlTestMapping[F] { self =>
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("movieById"),
-            SqlRoot("moviesByGenre"),
-            SqlRoot("moviesByGenres"),
-            SqlRoot("moviesReleasedBetween"),
-            SqlRoot("moviesLongerThan"),
-            SqlRoot("moviesShownLaterThan"),
-            SqlRoot("moviesShownBetween"),
-            SqlRoot("longMovies")
+            SqlObject("movieById"),
+            SqlObject("moviesByGenre"),
+            SqlObject("moviesByGenres"),
+            SqlObject("moviesReleasedBetween"),
+            SqlObject("moviesLongerThan"),
+            SqlObject("moviesShownLaterThan"),
+            SqlObject("moviesShownBetween"),
+            SqlObject("longMovies")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlMovieSpec.scala
+++ b/modules/sql/src/test/scala/SqlMovieSpec.scala
@@ -453,4 +453,30 @@ trait SqlMovieSpec extends AnyFunSuite {
 
     assert(res == expected)
   }
+
+  test("query with bogus hidden attribute") {
+    val query = """
+      query {
+        moviesByGenre(genre: COMEDY) {
+          title
+          isLong
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unknown field 'isLong' in select"
+          }
+        ]
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
 }

--- a/modules/sql/src/test/scala/SqlPaging1Mapping.scala
+++ b/modules/sql/src/test/scala/SqlPaging1Mapping.scala
@@ -1,0 +1,168 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.Order
+import cats.implicits._
+
+import edu.gemini.grackle._, syntax._
+import Cursor.Env
+import Query.{Binding, Count, Empty, Environment, Limit, Offset, OrderBy, OrderSelection, OrderSelections, Select}
+import QueryCompiler.SelectElaborator
+import Value.IntValue
+import QueryInterpreter.mkOneError
+
+// Mapping illustrating paging in "counted" style: paged results can
+// report the current offet, limit and total number of items in the
+// underlying list.
+//
+// This implmentation will only ever fetch up to the requested number
+// of items, and will include an SQL COUNT if the query includes `total`.
+trait SqlPaging1Mapping[F[_]] extends SqlTestMapping[F] {
+  object root extends RootDef {
+    val numCountries = col("num_countries", int8)
+  }
+
+  object country extends TableDef("country") {
+    val code         = col("code", bpchar(3))
+    val name         = col("name", text)
+    val numCities    = col("num_cities", int8)
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", int4)
+    val countrycode = col("countrycode", bpchar(3))
+    val name        = col("name", text)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        countries(offset: Int!, limit: Int!): PagedCountry!
+      }
+      type PagedCountry {
+        offset: Int!
+        limit: Int!
+        total: Int!
+        items: [Country!]!
+      }
+      type Country {
+        code: String!
+        name: String!
+        cities(offset: Int, limit: Int): PagedCity!
+      }
+      type PagedCity {
+        offset: Int!
+        limit: Int!
+        total: Int!
+        items: [City!]!
+      }
+      type City {
+        name: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val PagedCountryType = schema.ref("PagedCountry")
+  val CountryType = schema.ref("Country")
+  val PagedCityType = schema.ref("PagedCity")
+  val CityType = schema.ref("City")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlObject("countries"),
+          )
+      ),
+      ObjectMapping(
+        tpe = PagedCountryType,
+        fieldMappings =
+          List(
+            CursorField("offset", genValue("countryOffset"), Nil),
+            CursorField("limit", genValue("countryLimit"), Nil),
+            SqlField("total", root.numCountries),
+            SqlObject("items")
+          )
+      ),
+      ObjectMapping(
+        tpe = CountryType,
+        fieldMappings =
+          List(
+            SqlField("code", country.code, key = true),
+            SqlField("name", country.name),
+            SqlObject("cities")
+          )
+      ),
+      ObjectMapping(
+        tpe = PagedCityType,
+        fieldMappings =
+          List(
+            SqlField("code", country.code, key = true, hidden = true),
+            SqlObject("items", Join(country.code, city.countrycode)),
+            CursorField("offset", genValue("cityOffset"), Nil),
+            CursorField("limit", genValue("cityLimit"), Nil),
+            SqlField("total", country.numCities),
+          )
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings =
+          List(
+            SqlField("id", city.id, key = true, hidden = true),
+            SqlField("countrycode", city.countrycode, hidden = true),
+            SqlField("name", city.name)
+          )
+      )
+    )
+
+  def genValue(key: String)(c: Cursor): Result[Int] =
+    c.env[Int](key).toRightIor(mkOneError(s"Missing key '$key'"))
+
+  def transformChild[T: Order](query: Query, orderTerm: Term[T], off: Int, lim: Int): Result[Query] =
+    Query.mapFields(query) {
+      case Select("items", Nil, child) =>
+        def order(query: Query): Query =
+          OrderBy(OrderSelections(List(OrderSelection(orderTerm))), query)
+
+        def offset(query: Query): Query =
+          if (off < 1) query
+          else Offset(off, query)
+
+        def limit(query: Query): Query =
+          if (lim < 1) query
+          else Limit(lim, query)
+
+        Select("items", Nil, limit(offset(order(child)))).rightIor
+
+      case other => other.rightIor
+    }
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("countries", List(Binding("offset", IntValue(off)), Binding("limit", IntValue(lim))), child) => {
+        transformChild[String](child, CountryType / "code", off, lim).map { child0 =>
+          Select("countries", Nil, Environment(Env("countryOffset" -> off, "countryLimit" -> lim), child0))
+        }
+      }
+    },
+    PagedCountryType -> {
+      case Select("total", Nil, Empty) =>
+        Count("total", Select("items", Nil, Select("code", Nil, Empty))).rightIor
+    },
+    CountryType -> {
+      case Select("cities", List(Binding("offset", IntValue(off)), Binding("limit", IntValue(lim))), child) => {
+        transformChild[String](child, CityType / "name", off, lim).map { child0 =>
+          Select("cities", Nil, Environment(Env("cityOffset" -> off, "cityLimit" -> lim), child0))
+        }
+      }
+    },
+    PagedCityType -> {
+      case Select("total", Nil, Empty) =>
+        Count("total", Select("items", Nil, Select("id", Nil, Empty))).rightIor
+    }
+  ))
+}

--- a/modules/sql/src/test/scala/SqlPaging1Spec.scala
+++ b/modules/sql/src/test/scala/SqlPaging1Spec.scala
@@ -1,0 +1,735 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlPaging1Spec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("paging (initial)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 0,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (offset)") {
+    val query = """
+      query {
+        countries(offset: 2, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 2,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              },
+              {
+                "code" : "AIA",
+                "name" : "Anguilla"
+              },
+              {
+                "code" : "ALB",
+                "name" : "Albania"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (final, over)") {
+    val query = """
+      query {
+        countries(offset: 237, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 237,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              },
+              {
+                "code" : "ZWE",
+                "name" : "Zimbabwe"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (final, exact)") {
+    val query = """
+      query {
+        countries(offset: 236, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 236,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "ZAF",
+                "name" : "South Africa"
+              },
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              },
+              {
+                "code" : "ZWE",
+                "name" : "Zimbabwe"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (near end, more)") {
+    val query = """
+      query {
+        countries(offset: 235, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 235,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "YUG",
+                "name" : "Yugoslavia"
+              },
+              {
+                "code" : "ZAF",
+                "name" : "South Africa"
+              },
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only bounds, has more)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          offset
+          limit
+          total
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 0,
+            "limit" : 3,
+            "total" : 239
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only bounds, no more)") {
+    val query = """
+      query {
+        countries(offset: 236, limit: 3) {
+          offset
+          limit
+          total
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 236,
+            "limit" : 3,
+            "total" : 239
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (aliasing)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          foo:offset
+          bar:limit
+          baz:total
+          quux:items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "foo" : 0,
+            "bar" : 3,
+            "baz" : 239,
+            "quux" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (introspection)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+          offset
+          limit
+          total
+          items {
+            __typename
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry",
+            "offset" : 0,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "__typename" : "Country",
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "__typename" : "Country",
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "__typename" : "Country",
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (introspection, no items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+          offset
+          limit
+          total
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry",
+            "offset" : 0,
+            "limit" : 3,
+            "total" : 239
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only introspection)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry"
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              offset
+              limit
+              total
+              items {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 0,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "offset" : 0,
+                  "limit" : 2,
+                  "total" : 1,
+                  "items" : [
+                    {
+                      "name" : "Oranjestad"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "offset" : 0,
+                  "limit" : 2,
+                  "total" : 4,
+                  "items" : [
+                    {
+                      "name" : "Herat"
+                    },
+                    {
+                      "name" : "Kabul"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "offset" : 0,
+                  "limit" : 2,
+                  "total" : 5,
+                  "items" : [
+                    {
+                      "name" : "Benguela"
+                    },
+                    {
+                      "name" : "Huambo"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested, only items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              items {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Oranjestad"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Herat"
+                    },
+                    {
+                      "name" : "Kabul"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Benguela"
+                    },
+                    {
+                      "name" : "Huambo"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested, only bounds)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          offset
+          limit
+          total
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              offset
+              limit
+              total
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "offset" : 0,
+            "limit" : 3,
+            "total" : 239,
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "offset" : 0,
+                  "limit" : 2,
+                  "total" : 1
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "offset" : 0,
+                  "limit" : 2,
+                  "total" : 4
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "offset" : 0,
+                  "limit" : 2,
+                  "total" : 5
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}

--- a/modules/sql/src/test/scala/SqlPaging2Mapping.scala
+++ b/modules/sql/src/test/scala/SqlPaging2Mapping.scala
@@ -1,0 +1,169 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.Order
+import cats.implicits._
+
+import edu.gemini.grackle._, syntax._
+import Cursor.Env
+import Query.{Binding, Count, Empty, Environment, Group, Limit, Offset, OrderBy, OrderSelection, OrderSelections, Select}
+import QueryCompiler.SelectElaborator
+import Value.IntValue
+
+// Mapping illustrating paging in "has more" style: paged results can
+// report whether there are more elements beyond the current sub list.
+//
+// This implmentation will only ever fetch up to the requested number
+// of items, and will include an SQL COUNT if the query includes `hasMore`.
+trait SqlPaging2Mapping[F[_]] extends SqlTestMapping[F] {
+  object root extends RootDef {
+    val numCountries = col("num_countries", int8)
+  }
+
+  object country extends TableDef("country") {
+    val code      = col("code", bpchar(3))
+    val name      = col("name", text)
+    val numCities = col("num_cities", int8)
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", int4)
+    val countrycode = col("countrycode", bpchar(3))
+    val name        = col("name", text)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        countries(offset: Int, limit: Int): PagedCountry!
+      }
+      type PagedCountry {
+        items: [Country!]!
+        hasMore: Boolean!
+      }
+      type Country {
+        code: String!
+        name: String!
+        cities(offset: Int, limit: Int): PagedCity!
+      }
+      type PagedCity {
+        items: [City!]!
+        hasMore: Boolean!
+      }
+      type City {
+        name: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val PagedCountryType = schema.ref("PagedCountry")
+  val CountryType = schema.ref("Country")
+  val PagedCityType = schema.ref("PagedCity")
+  val CityType = schema.ref("City")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlObject("countries"),
+          )
+      ),
+      ObjectMapping(
+        tpe = PagedCountryType,
+        fieldMappings =
+          List(
+            SqlObject("items"),
+            CursorField("hasMore", genHasMore("countryLast", "numCountries"), List("numCountries")),
+            SqlField("numCountries", root.numCountries, hidden = true)
+          )
+      ),
+      ObjectMapping(
+        tpe = CountryType,
+        fieldMappings =
+          List(
+            SqlField("code", country.code, key = true),
+            SqlField("name", country.name),
+            SqlObject("cities")
+          ),
+      ),
+      ObjectMapping(
+        tpe = PagedCityType,
+        fieldMappings =
+          List(
+            SqlField("code", country.code, key = true, hidden = true),
+            SqlObject("items", Join(country.code, city.countrycode)),
+            CursorField("hasMore", genHasMore("cityLast", "numCities"), List("numCities")),
+            SqlField("numCities", country.numCities, hidden = true)
+          )
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings =
+          List(
+            SqlField("id", city.id, key = true, hidden = true),
+            SqlField("countrycode", city.countrycode, hidden = true),
+            SqlField("name", city.name)
+          )
+      )
+    )
+
+  def genHasMore(lastKey: String, numField: String)(c: Cursor): Result[Boolean] =
+    for {
+      last <- c.envR[Int](lastKey)
+      num  <- c.fieldAs[Long](numField)
+    } yield num > last
+
+  def transformChild[T: Order](query: Query, orderTerm: Term[T], off: Int, lim: Int): Result[Query] =
+    Query.mapFields(query) {
+      case Select("items", Nil, child) =>
+        def order(query: Query): Query =
+          OrderBy(OrderSelections(List(OrderSelection(orderTerm))), query)
+
+        def offset(query: Query): Query =
+          if (off < 1) query
+          else Offset(off, query)
+
+        def limit(query: Query): Query =
+          if (lim < 1) query
+          else Limit(lim, query)
+
+        Select("items", Nil, limit(offset(order(child)))).rightIor
+
+      case other => other.rightIor
+    }
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("countries", List(Binding("offset", IntValue(off)), Binding("limit", IntValue(lim))), child) => {
+        transformChild[String](child, CountryType / "code", off, lim).map { child0 =>
+          Select("countries", Nil, Environment(Env("countryLast" -> (off+lim)), child0))
+        }
+      }
+    },
+    PagedCountryType -> {
+      case s@Select("hasMore", Nil, Empty) =>
+        Group(List(
+          s,
+          Count("numCountries", Select("items", Nil, Select("code", Nil, Empty)))
+        )).rightIor
+    },
+    CountryType -> {
+      case Select("cities", List(Binding("offset", IntValue(off)), Binding("limit", IntValue(lim))), child) => {
+        transformChild[String](child, CityType / "name", off, lim).map { child0 =>
+          Select("cities", Nil, Environment(Env("cityLast" -> (off+lim)), child0))
+        }
+      }
+    },
+    PagedCityType -> {
+      case s@Select("hasMore", Nil, Empty) =>
+        Group(List(
+          s,
+          Count("numCities", Select("items", Nil, Select("id", Nil, Empty)))
+        )).rightIor
+    }
+  ))
+}

--- a/modules/sql/src/test/scala/SqlPaging2Spec.scala
+++ b/modules/sql/src/test/scala/SqlPaging2Spec.scala
@@ -1,0 +1,671 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlPaging2Spec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("paging (initial)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true,
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (offset)") {
+    val query = """
+      query {
+        countries(offset: 2, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true,
+            "items" : [
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              },
+              {
+                "code" : "AIA",
+                "name" : "Anguilla"
+              },
+              {
+                "code" : "ALB",
+                "name" : "Albania"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (final, over)") {
+    val query = """
+      query {
+        countries(offset: 237, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : false,
+            "items" : [
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              },
+              {
+                "code" : "ZWE",
+                "name" : "Zimbabwe"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (final, exact)") {
+    val query = """
+      query {
+        countries(offset: 236, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : false,
+            "items" : [
+              {
+                "code" : "ZAF",
+                "name" : "South Africa"
+              },
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              },
+              {
+                "code" : "ZWE",
+                "name" : "Zimbabwe"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (near end, more)") {
+    val query = """
+      query {
+        countries(offset: 235, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true,
+            "items" : [
+              {
+                "code" : "YUG",
+                "name" : "Yugoslavia"
+              },
+              {
+                "code" : "ZAF",
+                "name" : "South Africa"
+              },
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only has more, has more)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only has more, no more)") {
+    val query = """
+      query {
+        countries(offset: 236, limit: 3) {
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : false
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (aliasing)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          foo: items {
+            code
+            name
+          }
+          bar: hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "foo" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ],
+            "bar" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (introspection)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+          items {
+            __typename
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry",
+            "items" : [
+              {
+                "__typename" : "Country",
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "__typename" : "Country",
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "__typename" : "Country",
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ],
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (introspection, no items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry",
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only introspection)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry"
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              items {
+                name
+              }
+              hasMore
+            }
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Oranjestad"
+                    }
+                  ],
+                  "hasMore" : false
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Herat"
+                    },
+                    {
+                      "name" : "Kabul"
+                    }
+                  ],
+                  "hasMore" : true
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Benguela"
+                    },
+                    {
+                      "name" : "Huambo"
+                    }
+                  ],
+                  "hasMore" : true
+                }
+              }
+            ],
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested, only items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              items {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Oranjestad"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Herat"
+                    },
+                    {
+                      "name" : "Kabul"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Benguela"
+                    },
+                    {
+                      "name" : "Huambo"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested, only has more)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              hasMore
+            }
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "hasMore" : false
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "hasMore" : true
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "hasMore" : true
+                }
+              }
+            ],
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}

--- a/modules/sql/src/test/scala/SqlPaging3Mapping.scala
+++ b/modules/sql/src/test/scala/SqlPaging3Mapping.scala
@@ -1,0 +1,218 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.Order
+import cats.implicits._
+
+import edu.gemini.grackle._, syntax._
+import Cursor.{Env, ListTransformCursor}
+import Query.{Binding, Count, Empty, Environment, Group, Limit, Offset, OrderBy, OrderSelection, OrderSelections, Select, TransformCursor}
+import QueryCompiler.SelectElaborator
+import Value.IntValue
+import QueryInterpreter.mkErrorResult
+
+// Mapping illustrating paging in "has more" style: paged results can report
+// whether there are more elements beyond the current sub list.
+//
+// In this implementation, if the query includes both `hasMore` and `items`
+// then the compiled SQL query will overfetch by 1 item and compute `hasMore`
+// based on the presence or absence of that extra item in the result. A
+// `TransformCursor` is used to post-process the result items, removing any
+// extra element before the result is returned to the client.
+//
+// If `hasMore` isn't included in the query then only the requested number of
+// items will be fetched. If `items` isn't included in the query, then
+// `hasMore` will be compiled to an SQL COUNT.
+trait SqlPaging3Mapping[F[_]] extends SqlTestMapping[F] {
+  object root extends RootDef {
+    val numCountries = col("num_countries", int8)
+  }
+
+  object country extends TableDef("country") {
+    val code      = col("code", bpchar(3))
+    val name      = col("name", text)
+    val numCities = col("num_cities", int8)
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", int4)
+    val countrycode = col("countrycode", bpchar(3))
+    val name        = col("name", text)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        countries(offset: Int, limit: Int): PagedCountry!
+      }
+      type PagedCountry {
+        items: [Country!]!
+        hasMore: Boolean!
+      }
+      type Country {
+        code: String!
+        name: String!
+        cities(offset: Int, limit: Int): PagedCity!
+      }
+      type PagedCity {
+        items: [City!]!
+        hasMore: Boolean!
+      }
+      type City {
+        name: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val PagedCountryType = schema.ref("PagedCountry")
+  val CountryType = schema.ref("Country")
+  val PagedCityType = schema.ref("PagedCity")
+  val CityType = schema.ref("City")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlObject("countries"),
+          )
+      ),
+      ObjectMapping(
+        tpe = PagedCountryType,
+        fieldMappings =
+          List(
+            SqlObject("items"),
+            CursorField("hasMore", genHasMore("country", "numCountries")),
+            SqlField("numCountries", root.numCountries, hidden = true)
+          )
+      ),
+      ObjectMapping(
+        tpe = CountryType,
+        fieldMappings =
+          List(
+            SqlField("code", country.code, key = true),
+            SqlField("name", country.name),
+            SqlObject("cities")
+          )
+      ),
+      ObjectMapping(
+        tpe = PagedCityType,
+        fieldMappings =
+          List(
+            SqlField("code", country.code, key = true, hidden = true),
+            SqlObject("items", Join(country.code, city.countrycode)),
+            CursorField("hasMore", genHasMore("city", "numCities")),
+            SqlField("numCities", country.numCities, hidden = true)
+          )
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings =
+          List(
+            SqlField("id", city.id, key = true, hidden = true),
+            SqlField("countrycode", city.countrycode, hidden = true),
+            SqlField("name", city.name)
+          )
+      )
+    )
+
+  def genHasMore(keyPrefix: String, countField: String)(c: Cursor): Result[Boolean] = {
+    val limitKey = keyPrefix+"Limit"
+    val lastKey = keyPrefix+"Last"
+    val aliasKey = keyPrefix+"Alias"
+    if(c.envContains(limitKey)) {
+      for {
+        limit <- c.envR[Int](limitKey)
+        alias <- c.envR[Option[String]](aliasKey)
+        items <- c.field("items", alias)
+        size  <- items.listSize
+      } yield limit < 0 || size > limit
+    } else if(c.envContains(lastKey)) {
+      for {
+        last <- c.envR[Int](lastKey)
+        num  <- c.fieldAs[Long](countField)
+      } yield num > last
+    } else
+      mkErrorResult("Result has unexpected shape")
+  }
+
+  def genItems(keyPrefix: String)(c: Cursor): Result[Cursor] = {
+    val limitKey = keyPrefix+"Limit"
+    for {
+      limit <- c.envR[Int](limitKey)
+      size  <- c.listSize
+      elems <- c.asList(Seq)
+    } yield {
+      if(size <= limit) c
+      else ListTransformCursor(c, size-1, elems.init)
+    }
+  }
+
+  def transformChild[T: Order](query: Query, keyPrefix: String, orderTerm: Term[T], off: Int, lim: Int, hasHasMore: Boolean): Result[Query] =
+    Query.mapFields(query) {
+      case Select("items", Nil, child) =>
+        def order(query: Query): Query =
+          OrderBy(OrderSelections(List(OrderSelection(orderTerm))), query)
+
+        def offset(query: Query): Query =
+          if (off < 1) query
+          else Offset(off, query)
+
+        def limit(query: Query): Query =
+          if (lim < 1) query
+          else Limit(if (hasHasMore) lim+1 else lim, query)
+
+        if(hasHasMore)
+          Select("items", Nil, TransformCursor(genItems(keyPrefix), limit(offset(order(child))))).rightIor
+        else
+          Select("items", Nil, limit(offset(order(child)))).rightIor
+
+      case other => other.rightIor
+    }
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("countries", List(Binding("offset", IntValue(off)), Binding("limit", IntValue(lim))), child) => {
+        val hasItems = Query.hasField(child, "items")
+        val hasHasMore = Query.hasField(child, "hasMore")
+        if(hasItems) {
+          val itemAlias = Query.fieldAlias(child, "items")
+          transformChild[String](child, "country", CountryType / "code", off, lim, hasHasMore).map { child0 =>
+            Select("countries", Nil, Environment(Env("countryLimit" -> lim, "countryAlias" -> itemAlias), child0))
+          }
+        } else
+          Select("countries", Nil,
+            Environment(Env("countryLast" -> (off+lim)),
+              Group(List(
+                Count("numCountries", Select("items", Nil, Select("code", Nil, Empty))),
+                child
+              ))
+            )
+          ).rightIor
+      }
+    },
+    CountryType -> {
+      case Select("cities", List(Binding("offset", IntValue(off)), Binding("limit", IntValue(lim))), child) => {
+        val hasItems = Query.hasField(child, "items")
+        val hasHasMore = Query.hasField(child, "hasMore")
+        if(hasItems) {
+          val itemAlias = Query.fieldAlias(child, "items")
+          transformChild[String](child, "city", CityType / "name", off, lim, hasHasMore).map { child0 =>
+            Select("cities", Nil, Environment(Env("cityLimit" -> lim, "cityAlias" -> itemAlias), child0))
+          }
+        } else
+          Select("cities", Nil,
+            Environment(Env("cityLast" -> (off+lim)),
+              Group(List(
+                Count("numCities", Select("items", Nil, Select("id", Nil, Empty))),
+                child
+              ))
+            )
+          ).rightIor
+      }
+    }
+  ))
+}

--- a/modules/sql/src/test/scala/SqlPaging3Spec.scala
+++ b/modules/sql/src/test/scala/SqlPaging3Spec.scala
@@ -1,0 +1,671 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlPaging3Spec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("paging (initial)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true,
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (offset)") {
+    val query = """
+      query {
+        countries(offset: 2, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true,
+            "items" : [
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              },
+              {
+                "code" : "AIA",
+                "name" : "Anguilla"
+              },
+              {
+                "code" : "ALB",
+                "name" : "Albania"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (final, over)") {
+    val query = """
+      query {
+        countries(offset: 237, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : false,
+            "items" : [
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              },
+              {
+                "code" : "ZWE",
+                "name" : "Zimbabwe"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (final, exact)") {
+    val query = """
+      query {
+        countries(offset: 236, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : false,
+            "items" : [
+              {
+                "code" : "ZAF",
+                "name" : "South Africa"
+              },
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              },
+              {
+                "code" : "ZWE",
+                "name" : "Zimbabwe"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (near end, more)") {
+    val query = """
+      query {
+        countries(offset: 235, limit: 3) {
+          items {
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true,
+            "items" : [
+              {
+                "code" : "YUG",
+                "name" : "Yugoslavia"
+              },
+              {
+                "code" : "ZAF",
+                "name" : "South Africa"
+              },
+              {
+                "code" : "ZMB",
+                "name" : "Zambia"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only has more, has more)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only has more, no more)") {
+    val query = """
+      query {
+        countries(offset: 236, limit: 3) {
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "hasMore" : false
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (aliasing)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          foo: items {
+            code
+            name
+          }
+          bar: hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "foo" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ],
+            "bar" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (introspection)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+          items {
+            __typename
+            code
+            name
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry",
+            "items" : [
+              {
+                "__typename" : "Country",
+                "code" : "ABW",
+                "name" : "Aruba"
+              },
+              {
+                "__typename" : "Country",
+                "code" : "AFG",
+                "name" : "Afghanistan"
+              },
+              {
+                "__typename" : "Country",
+                "code" : "AGO",
+                "name" : "Angola"
+              }
+            ],
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (introspection, no items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry",
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (only introspection)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          __typename
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "__typename" : "PagedCountry"
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              items {
+                name
+              }
+              hasMore
+            }
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Oranjestad"
+                    }
+                  ],
+                  "hasMore" : false
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Herat"
+                    },
+                    {
+                      "name" : "Kabul"
+                    }
+                  ],
+                  "hasMore" : true
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Benguela"
+                    },
+                    {
+                      "name" : "Huambo"
+                    }
+                  ],
+                  "hasMore" : true
+                }
+              }
+            ],
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested, only items)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              items {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Oranjestad"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Herat"
+                    },
+                    {
+                      "name" : "Kabul"
+                    }
+                  ]
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "items" : [
+                    {
+                      "name" : "Benguela"
+                    },
+                    {
+                      "name" : "Huambo"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("paging (nested, only has more)") {
+    val query = """
+      query {
+        countries(offset: 0, limit: 3) {
+          items {
+            code
+            name
+            cities(offset: 0, limit: 2) {
+              hasMore
+            }
+          }
+          hasMore
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : {
+            "items" : [
+              {
+                "code" : "ABW",
+                "name" : "Aruba",
+                "cities" : {
+                  "hasMore" : false
+                }
+              },
+              {
+                "code" : "AFG",
+                "name" : "Afghanistan",
+                "cities" : {
+                  "hasMore" : true
+                }
+              },
+              {
+                "code" : "AGO",
+                "name" : "Angola",
+                "cities" : {
+                  "hasMore" : true
+                }
+              }
+            ],
+            "hasMore" : true
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}

--- a/modules/sql/src/test/scala/SqlProjectionMapping.scala
+++ b/modules/sql/src/test/scala/SqlProjectionMapping.scala
@@ -63,9 +63,9 @@ trait SqlProjectionMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("level0"),
-            SqlRoot("level1"),
-            SqlRoot("level2")
+            SqlObject("level0"),
+            SqlObject("level1"),
+            SqlObject("level2")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlRecursiveInterfacesMapping.scala
+++ b/modules/sql/src/test/scala/SqlRecursiveInterfacesMapping.scala
@@ -60,7 +60,7 @@ trait SqlRecursiveInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("items")
+            SqlObject("items")
           )
       ),
       SqlInterfaceMapping(

--- a/modules/sql/src/test/scala/SqlSiblingListsMapping.scala
+++ b/modules/sql/src/test/scala/SqlSiblingListsMapping.scala
@@ -66,7 +66,7 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("a")
+            SqlObject("a")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlTestMapping.scala
+++ b/modules/sql/src/test/scala/SqlTestMapping.scala
@@ -6,9 +6,9 @@ package edu.gemini.grackle.sql.test
 import org.tpolecat.sourcepos.SourcePos
 
 import edu.gemini.grackle._
-import sql.SqlMapping
+import sql.SqlMappingLike
 
-trait SqlTestMapping[F[_]] extends SqlMapping[F] { outer =>
+trait SqlTestMapping[F[_]] extends SqlMappingLike[F] { outer =>
   def bool: Codec
   def text: Codec
   def varchar: Codec

--- a/modules/sql/src/test/scala/SqlTreeMapping.scala
+++ b/modules/sql/src/test/scala/SqlTreeMapping.scala
@@ -39,7 +39,7 @@ trait SqlTreeMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("bintree")
+            SqlObject("bintree")
           )
       ),
       ObjectMapping(

--- a/modules/sql/src/test/scala/SqlUnionsMapping.scala
+++ b/modules/sql/src/test/scala/SqlUnionsMapping.scala
@@ -41,7 +41,7 @@ trait SqlUnionsMapping[F[_]] extends SqlTestMapping[F] {
         tpe = QueryType,
         fieldMappings =
           List(
-            SqlRoot("collection")
+            SqlObject("collection")
           )
       ),
       SqlUnionMapping(

--- a/modules/sql/src/test/scala/SqlWorldCompilerSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldCompilerSpec.scala
@@ -66,7 +66,7 @@ trait SqlWorldCompilerSpec extends AnyFunSuite {
     assert(
       stats == List(
         SqlStatsMonitor.SqlStats(
-          Query.Unique(Query.Filter(Eql(schema.ref("Country") / "code", Const("GBR")),Query.Select("name",List(),Query.Empty))),
+          Query.Select("country", Nil, Query.Unique(Query.Filter(Eql(schema.ref("Country") / "code",Const("GBR")),Query.Select("name",List(),Query.Empty)))),
           simpleRestrictedQuerySql,
           List("GBR"),
           1,
@@ -124,7 +124,7 @@ trait SqlWorldCompilerSpec extends AnyFunSuite {
     assert(
       stats == List(
         SqlStatsMonitor.SqlStats(
-          Query.Filter(Like(schema.ref("City") / "name","Linh%",true),Query.Select("name",List(),Query.Empty)),
+          Query.Select("cities", Nil, Query.Filter(Like(schema.ref("City") / "name","Linh%",true),Query.Select("name",List(),Query.Empty))),
           simpleFilteredQuerySql,
           List("Linh%"),
           3,

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -1764,4 +1764,133 @@ trait SqlWorldSpec extends AnyFunSuite {
 
     assertWeaklyEqual(res, expected)
   }
+
+  test("set inclusion") {
+    val query = """
+      query {
+        languages(languages: ["French", "German"]) {
+          language
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "languages" : [
+            {
+              "language" : "German"
+            },
+            {
+              "language" : "French"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("empty set inclusion") {
+    val query = """
+      query {
+        languages(languages: []) {
+          language
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "languages" : [
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("top-level count (1)") {
+    val query = """
+      query {
+        numCountries
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "numCountries" : 239
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("top-level count (2)") {
+    val query = """
+      query {
+        numCountries
+        city(id: 490) {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "numCountries" : 239,
+          "city" : {
+            "name" : "Brighton"
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("top-level count (3)") {
+    val query = """
+      query {
+        numCountries
+        country(code: "GBR") {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "numCountries" : 239,
+          "country" : {
+            "name" : "United Kingdom"
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
 }

--- a/profile/src/main/scala/Bench.scala
+++ b/profile/src/main/scala/Bench.scala
@@ -112,13 +112,13 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
       ObjectMapping(
         tpe = QueryType,
         fieldMappings = List(
-          SqlRoot("cities"),
-          SqlRoot("city"),
-          SqlRoot("country"),
-          SqlRoot("countries"),
-          SqlRoot("language"),
-          SqlRoot("search"),
-          SqlRoot("search2")
+          SqlObject("cities"),
+          SqlObject("city"),
+          SqlObject("country"),
+          SqlObject("countries"),
+          SqlObject("language"),
+          SqlObject("search"),
+          SqlObject("search2")
         )
       ),
       ObjectMapping(


### PR DESCRIPTION
+ `RootMappings` have been removed. Roots are now ordinary fields of Query/Mutation/Subscription mappings.

+ Mappings have been split into an `XxxMappingLike` trait which carries the definitions and logic, and an abstract class `XxxMapping` with a constructor. This enables arbitrary mappings to be mixed together while retaining a simple interface for client extension.

+ As a replacement for` RootMapping`, `Mapping` now defines a single `RootCursor` type which is focussed on the Query/Mutation/Subscription root type. Mapping subtypes contribute their own field mapping types by overriding `mkCursorForField`, which is called from the field method of `Cursor` during result construction traversal.

+ The effect logic of `RootMapping` has been moved to a new `RootEffect` type. `RootEffects` can perform an initial effect prior to computing a root `Cursor` and root query. See `MutationSpec` for an example.

+ A consequence of the above is that the various `Mapping` subtypes share more capabilities, for instance, the circe and generic mappings now support hidden and computed fields, and now also now support effects via the `RootEffect` infrastructure.

+ Added `TransformCursor` to the query algebra to support query result manipulation, post query execution, but prior to result construction.

+ Added `listSize`, `isDefined` and `envContains` to `Cursor` in support of `TransformCursor`.

+ The SQL mapping now supports a synthetic root table defined via `RootDef` allowing top level non-structured fields. This allows top level aggregation-like queries to be supported, eg. a count of elements of a collection.

+ Multiple root queries for a single mapping will now be handled together with respect to the SQL mappings. This means that multiple root queries will now be compiled and executed as a single SQL UNION query rather than as multiple queries sequentially. Combined with the previous bullet this means we can now, for example, fetch both a collection of items and an aggregate over that collection (eg. its size) in a single SQL query (in this case the query would be an SQL UNION of the count with the items).

+ Embedded subquery columns are now supported.

+ `In` predicates with an empty match set are now compiled to false, and child SQL queries will be eliminated where appropriate. Where this results in an empty top level SQL query this is now handled correctly.

+ The `CursorFieldJson` field mapping has been moved to the circe module.

+ Leaf encoders are now memoized in `Mapping` and the logic is shared between all `Mapping` subtypes.

+ The `LeafCursor` implementation has been moved to Mapping and is reused across all Mapping subtypes.

+ Added tests illustrating three approaches to paging.

+ Updated the code samples in the tutorial.