### PR TITLE
Interface validation rework

### DIFF
--- a/modules/core/src/test/scala/schema/SchemaSpec.scala
+++ b/modules/core/src/test/scala/schema/SchemaSpec.scala
@@ -396,4 +396,33 @@ final class SchemaSpec extends CatsSuite {
     schema"scalar Foo".queryType
   }
 
+  test("schema validation: fields implementing interfaces can be subtypes") {
+    val schema = Schema("""
+      type Query {
+        foo: Int
+      }
+
+      interface Edge {
+        node: String
+      }
+
+      interface Connection {
+        edges: [Edge!]!
+      }
+
+      type MyEdge implements Edge {
+        node: String
+      }
+
+      type MyConnection implements Connection {
+        edges: [MyEdge!]!
+      }
+    """)
+
+    schema match {
+      case Ior.Right(a) => assert(a.types.map(_.name) == List("MyEdge", "MyCinnection"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
 }


### PR DESCRIPTION
I've been reworking Grackle's interface validation code for schemas to more closely follow the algorithm outlined in the latest graphql spec and to cover some cases that the previous implementation did not (namely the former implementation did not deal with the case where a field is a subtype of that defined by the interface).  From this work a couple of design questions have arise that I'd be keen to get feedback on:

* I'm finding a need to dealias type aliases and invoke subtyping logic, both of these are already sipported by the `Schema` type however presently the validation is invoked before the schema is populated and so I'm wondering whether I should move where the validation happens, change the way schemas are constructed or re-implement this logic just for validation purposes?
* both objects and interfaces can implement interfaces but presently they lack a common supertype that exposes what interfaces they are attempting to implement, should I introduce one or adopt some other strategy?