### PR TITLE
add some convenience syntax

### DIFF
--- a/modules/circe/src/test/scala/CirceEffectData.scala
+++ b/modules/circe/src/test/scala/CirceEffectData.scala
@@ -53,7 +53,7 @@ class TestCirceEffectMapping[F[_]: Sync] extends CirceMapping[F] {
             )
           ),
 
-          // Compute a Json, let the implemenation handle the cursor
+          // Compute a Json, let the implementation handle the cursor
           RootEffect.computeJson("bar")((_, _, _) =>
             Sync[F].delay(println(s"!!! a side effect! (2) !!!")).as(
               Result(Json.obj(
@@ -63,7 +63,7 @@ class TestCirceEffectMapping[F[_]: Sync] extends CirceMapping[F] {
             )
           ),
 
-          // Compute an encodable value, let the implemenation handle json and the cursor
+          // Compute an encodable value, let the implementation handle json and the cursor
           RootEffect.computeEncodable("baz")((_, _, _) =>
             Sync[F].delay(println(s"!!! a side effect! (3) !!!")).as(
               Result(Struct(44, "hee"))

--- a/modules/circe/src/test/scala/CirceEffectData.scala
+++ b/modules/circe/src/test/scala/CirceEffectData.scala
@@ -6,6 +6,7 @@ package circetests
 
 import cats.implicits._
 import cats.effect.Sync
+import io.circe.Encoder
 import io.circe.Json
 
 import edu.gemini.grackle.circe.CirceMapping
@@ -16,6 +17,8 @@ class TestCirceEffectMapping[F[_]: Sync] extends CirceMapping[F] {
     schema"""
       type Query { 
         foo: Struct!
+        bar: Struct!
+        baz: Struct!
       }
       type Struct {
         n: Int!
@@ -26,10 +29,19 @@ class TestCirceEffectMapping[F[_]: Sync] extends CirceMapping[F] {
   val QueryType = schema.ref("Query")
   val StructType = schema.ref("Struct")
 
+  case class Struct(n: Int, s: String)
+  implicit val EncodeStruct: Encoder[Struct] = s => 
+    Json.obj(
+      "n" -> Json.fromInt(s.n), 
+      "s" -> Json.fromString(s.s)
+    )
+  
   val typeMappings = List(
     ObjectMapping(
       schema.ref("Query"), 
         List(
+
+          // Compute a CirceCursor
           RootEffect.computeCursor("foo")((_, t, e) =>
             Sync[F].delay(println(s"!!! a side effect! !!!")).as(
               Result(circeCursor(t, e, 
@@ -39,7 +51,25 @@ class TestCirceEffectMapping[F[_]: Sync] extends CirceMapping[F] {
                 )
               ))
             )
-          )           
+          ),
+
+          // Compute a Json, let the implemenation handle the cursor
+          RootEffect.computeJson("bar")((_, _, _) =>
+            Sync[F].delay(println(s"!!! a side effect! (2) !!!")).as(
+              Result(Json.obj(
+                "n" -> Json.fromInt(42), 
+                "s" -> Json.fromString("ho")
+              ))
+            )
+          ),
+
+          // Compute an encodable value, let the implemenation handle json and the cursor
+          RootEffect.computeEncodable("baz")((_, _, _) =>
+            Sync[F].delay(println(s"!!! a side effect! (3) !!!")).as(
+              Result(Struct(44, "hee"))
+            )
+          ),
+
         )
     ),
   )

--- a/modules/circe/src/test/scala/CirceEffectSpec.scala
+++ b/modules/circe/src/test/scala/CirceEffectSpec.scala
@@ -10,10 +10,19 @@ import cats.tests.CatsSuite
 import edu.gemini.grackle.syntax._
 
 final class CirceEffectSpec extends CatsSuite {
+
   test("circe effect") {
     val query = """
       query {
         foo {
+          s,
+          n
+        }
+        bar {
+          s,
+          n
+        },
+        baz {
           s,
           n
         }
@@ -26,6 +35,14 @@ final class CirceEffectSpec extends CatsSuite {
           "foo" : {
             "s" : "hi",
             "n" : 42
+          },
+          "bar" : {
+            "s" : "ho",
+            "n" : 42
+          },
+          "baz" : {
+            "s" : "hee",
+            "n" : 44
           }
         }
       }
@@ -36,4 +53,5 @@ final class CirceEffectSpec extends CatsSuite {
 
     assert(res == expected)
   }
+  
 }


### PR DESCRIPTION
This adds some convenience methods to `RootEffect` via syntax on `CirceMapping`, allowing computation of `F[Result[Json]]` and `F[Result[A]]` (given `Encoder[A]`) instead of computing a `CirceCursor`, which is usually entirely mechanical.