### PR TITLE
Make CursorBuilder independent of mapping scope, add contramap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val Scala3 = "3.2.1"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.10"
+ThisBuild / tlBaseVersion    := "0.11"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/generic/src/main/scala/CursorBuilder.scala
+++ b/modules/generic/src/main/scala/CursorBuilder.scala
@@ -1,0 +1,180 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+package generic
+
+import scala.collection.Factory
+
+import cats.implicits._
+import io.circe.{Encoder, Json}
+
+import Cursor.{AbstractCursor, Context, Env}
+import QueryInterpreter.mkOneError
+
+trait CursorBuilder[T] {
+  def tpe: Type
+  def build(context: Context, focus: T, parent: Option[Cursor] = None, env: Env = Env.empty): Result[Cursor]
+}
+
+object CursorBuilder {
+  def apply[T](implicit cb: CursorBuilder[T]): CursorBuilder[T] = cb
+
+  import ScalarType._
+
+  implicit val stringCursorBuilder: CursorBuilder[String] = {
+    case class StringCursor(context: Context, focus: String, parent: Option[Cursor], env: Env)
+        extends PrimitiveCursor[String] {
+      def withEnv(env0: Env): Cursor    = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromString(focus).rightIor
+    }
+    new CursorBuilder[String] {
+      val tpe = StringType
+      def build(context: Context, focus: String, parent: Option[Cursor], env: Env): Result[Cursor] =
+        StringCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit val intCursorBuilder: CursorBuilder[Int] = {
+    case class IntCursor(context: Context, focus: Int, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Int] {
+      def withEnv(env0: Env): Cursor    = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromInt(focus).rightIor
+    }
+    new CursorBuilder[Int] {
+      val tpe = IntType
+      def build(context: Context, focus: Int, parent: Option[Cursor], env: Env): Result[Cursor] =
+        IntCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit val longCursorBuilder: CursorBuilder[Long] = {
+    case class LongCursor(context: Context, focus: Long, parent: Option[Cursor], env: Env)
+        extends PrimitiveCursor[Long] {
+      def withEnv(env0: Env): Cursor    = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromLong(focus).rightIor
+    }
+    new CursorBuilder[Long] {
+      val tpe = IntType
+      def build(context: Context, focus: Long, parent: Option[Cursor], env: Env): Result[Cursor] =
+        LongCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit val floatCursorBuilder: CursorBuilder[Float] = {
+    case class FloatCursor(context: Context, focus: Float, parent: Option[Cursor], env: Env)
+        extends PrimitiveCursor[Float] {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] =
+        Json.fromFloat(focus).toRightIor(mkOneError(s"Unrepresentable float %focus"))
+    }
+    new CursorBuilder[Float] {
+      val tpe = FloatType
+      def build(context: Context, focus: Float, parent: Option[Cursor], env: Env): Result[Cursor] =
+        FloatCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit val doubleCursorBuilder: CursorBuilder[Double] = {
+    case class DoubleCursor(context: Context, focus: Double, parent: Option[Cursor], env: Env)
+        extends PrimitiveCursor[Double] {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] =
+        Json.fromDouble(focus).toRightIor(mkOneError(s"Unrepresentable double %focus"))
+    }
+    new CursorBuilder[Double] {
+      val tpe = FloatType
+      def build(context: Context, focus: Double, parent: Option[Cursor], env: Env): Result[Cursor] =
+        DoubleCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit val booleanCursorBuilder: CursorBuilder[Boolean] = {
+    case class BooleanCursor(context: Context, focus: Boolean, parent: Option[Cursor], env: Env)
+        extends PrimitiveCursor[Boolean] {
+      def withEnv(env0: Env): Cursor    = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromBoolean(focus).rightIor
+    }
+    new CursorBuilder[Boolean] {
+      val tpe = BooleanType
+      def build(context: Context, focus: Boolean, parent: Option[Cursor], env: Env): Result[Cursor] =
+        BooleanCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  def deriveEnumerationCursorBuilder[T <: Enumeration#Value](tpe0: Type): CursorBuilder[T] = {
+    case class EnumerationCursor(context: Context, focus: T, parent: Option[Cursor], env: Env)
+        extends PrimitiveCursor[T] {
+      def withEnv(env0: Env): Cursor    = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromString(focus.toString).rightIor
+    }
+    new CursorBuilder[T] {
+      val tpe = tpe0
+      def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+        EnumerationCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit def enumerationCursorBuilder[T <: Enumeration#Value]: CursorBuilder[T] =
+    deriveEnumerationCursorBuilder(StringType)
+
+  implicit def optionCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[Option[T]] = {
+    case class OptionCursor(context: Context, focus: Option[T], parent: Option[Cursor], env: Env)
+        extends AbstractCursor {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+      override def isNullable: Boolean = true
+      override def asNullable: Result[Option[Cursor]] =
+        focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env))
+    }
+
+    new CursorBuilder[Option[T]] { outer =>
+      val tpe = NullableType(elemBuilder.tpe)
+      def build(context: Context, focus: Option[T], parent: Option[Cursor], env: Env): Result[Cursor] =
+        OptionCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  implicit def listCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[List[T]] = {
+    case class ListCursor(context: Context, focus: List[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+      override def preunique: Result[Cursor] = {
+        val listTpe = tpe.nonNull.list
+        copy(context = context.asType(listTpe)).rightIor
+      }
+
+      override def isList: Boolean = true
+      override def asList[C](factory: Factory[Cursor, C]): Result[C] =
+        focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env)).map(_.to(factory))
+    }
+
+    new CursorBuilder[List[T]] { outer =>
+      val tpe = ListType(elemBuilder.tpe)
+      def build(context: Context, focus: List[T], parent: Option[Cursor], env: Env): Result[Cursor] =
+        ListCursor(context.asType(tpe), focus, parent, env).rightIor
+    }
+  }
+
+  case class LeafCursor[T](context: Context, focus: T, encoder: Encoder[T], parent: Option[Cursor], env: Env)
+      extends AbstractCursor {
+    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+    override def isLeaf: Boolean      = true
+    override def asLeaf: Result[Json] = encoder(focus).rightIor
+  }
+
+  def deriveLeafCursorBuilder[T](tpe0: Type)(implicit encoder: Encoder[T]): CursorBuilder[T] =
+    new CursorBuilder[T] {
+      val tpe = tpe0
+      def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+        new LeafCursor(context.asType(tpe), focus, encoder, parent, env).rightIor
+    }
+
+  implicit def leafCursorBuilder[T](implicit encoder: Encoder[T]): CursorBuilder[T] =
+    deriveLeafCursorBuilder(StringType)
+}
+
+abstract class PrimitiveCursor[T] extends AbstractCursor {
+  val focus: T
+  override def isLeaf: Boolean = true
+}

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -4,19 +4,18 @@
 package edu.gemini.grackle
 package generic
 
-import scala.collection.Factory
-
 import cats.Monad
 import cats.implicits._
-import io.circe.{Encoder, Json}
 import org.tpolecat.sourcepos.SourcePos
 
-import Cursor.{AbstractCursor, Context, DeferredCursor, Env}
-import QueryInterpreter.mkOneError
+import Cursor.{Context, DeferredCursor, Env}
 
 abstract class GenericMapping[F[_]](implicit val M: Monad[F]) extends Mapping[F] with GenericMappingLike[F]
 
 trait GenericMappingLike[F[_]] extends ScalaVersionSpecificGenericMappingLike[F] {
+  
+  type CursorBuilder[T] = edu.gemini.grackle.generic.CursorBuilder[T]
+
   def genericCursor[T](path: Path, env: Env, t: T)(implicit cb: => CursorBuilder[T]): Result[Cursor] =
     if(path.isRoot)
       cb.build(Context(path.rootTpe), t, None, env)
@@ -55,166 +54,5 @@ trait GenericMappingLike[F[_]] extends ScalaVersionSpecificGenericMappingLike[F]
     def renameField(from: String, to: String): ObjectCursorBuilder[T]
     def transformFieldNames(f: String => String): ObjectCursorBuilder[T]
     def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: => CursorBuilder[U]): ObjectCursorBuilder[T]
-  }
-
-  trait CursorBuilder[T] { outer =>
-    def tpe: Type
-    def build(context: Context, focus: T, parent: Option[Cursor] = None, env: Env = Env.empty): Result[Cursor]
-  }
-
-  object CursorBuilder {
-    def apply[T](implicit cb: CursorBuilder[T]): CursorBuilder[T] = cb
-
-    import ScalarType._
-
-    implicit val stringCursorBuilder: CursorBuilder[String] = {
-      case class StringCursor(context: Context, focus: String, parent: Option[Cursor], env: Env) extends PrimitiveCursor[String] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] = Json.fromString(focus).rightIor
-      }
-      new CursorBuilder[String] {
-        val tpe = StringType
-        def build(context: Context, focus: String, parent: Option[Cursor], env: Env): Result[Cursor] =
-          StringCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit val intCursorBuilder: CursorBuilder[Int] = {
-      case class IntCursor(context: Context, focus: Int, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Int] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] = Json.fromInt(focus).rightIor
-      }
-      new CursorBuilder[Int] {
-        val tpe = IntType
-        def build(context: Context, focus: Int, parent: Option[Cursor], env: Env): Result[Cursor] =
-          IntCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit val longCursorBuilder: CursorBuilder[Long] = {
-      case class LongCursor(context: Context, focus: Long, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Long] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] = Json.fromLong(focus).rightIor
-      }
-      new CursorBuilder[Long] {
-        val tpe = IntType
-        def build(context: Context, focus: Long, parent: Option[Cursor], env: Env): Result[Cursor] =
-          LongCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit val floatCursorBuilder: CursorBuilder[Float] = {
-      case class FloatCursor(context: Context, focus: Float, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Float] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] =
-          Json.fromFloat(focus).toRightIor(mkOneError(s"Unrepresentable float %focus"))
-      }
-      new CursorBuilder[Float] {
-        val tpe = FloatType
-        def build(context: Context, focus: Float, parent: Option[Cursor], env: Env): Result[Cursor] =
-          FloatCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit val doubleCursorBuilder: CursorBuilder[Double] = {
-      case class DoubleCursor(context: Context, focus: Double, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Double] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] =
-          Json.fromDouble(focus).toRightIor(mkOneError(s"Unrepresentable double %focus"))
-      }
-      new CursorBuilder[Double] {
-        val tpe = FloatType
-        def build(context: Context, focus: Double, parent: Option[Cursor], env: Env): Result[Cursor] =
-          DoubleCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit val booleanCursorBuilder: CursorBuilder[Boolean] = {
-      case class BooleanCursor(context: Context, focus: Boolean, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Boolean] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] = Json.fromBoolean(focus).rightIor
-      }
-      new CursorBuilder[Boolean] {
-        val tpe = BooleanType
-        def build(context: Context, focus: Boolean, parent: Option[Cursor], env: Env): Result[Cursor] =
-          BooleanCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    def deriveEnumerationCursorBuilder[T <: Enumeration#Value](tpe0: Type): CursorBuilder[T] = {
-      case class EnumerationCursor(context: Context, focus: T, parent: Option[Cursor], env: Env) extends PrimitiveCursor[T] {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-        override def asLeaf: Result[Json] = Json.fromString(focus.toString).rightIor
-      }
-      new CursorBuilder[T] {
-        val tpe = tpe0
-        def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
-          EnumerationCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit def enumerationCursorBuilder[T <: Enumeration#Value]: CursorBuilder[T] =
-      deriveEnumerationCursorBuilder(StringType)
-
-    implicit def optionCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[Option[T]] = {
-      case class OptionCursor(context: Context, focus: Option[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
-        override def isNullable: Boolean = true
-        override def asNullable: Result[Option[Cursor]] = {
-          focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env))
-        }
-      }
-
-      new CursorBuilder[Option[T]] { outer =>
-        val tpe = NullableType(elemBuilder.tpe)
-        def build(context: Context, focus: Option[T], parent: Option[Cursor], env: Env): Result[Cursor] =
-          OptionCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    implicit def listCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[List[T]] = {
-      case class ListCursor(context: Context, focus: List[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
-        def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
-        override def preunique: Result[Cursor] = {
-          val listTpe = tpe.nonNull.list
-          copy(context = context.asType(listTpe)).rightIor
-        }
-
-        override def isList: Boolean = true
-        override def asList[C](factory: Factory[Cursor, C]): Result[C] = {
-          focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env)).map(_.to(factory))
-        }
-      }
-
-      new CursorBuilder[List[T]] { outer =>
-        val tpe = ListType(elemBuilder.tpe)
-        def build(context: Context, focus: List[T], parent: Option[Cursor], env: Env): Result[Cursor] =
-          ListCursor(context.asType(tpe), focus, parent, env).rightIor
-      }
-    }
-
-    case class LeafCursor[T](context: Context, focus: T, encoder: Encoder[T], parent: Option[Cursor], env: Env) extends AbstractCursor {
-      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
-      override def isLeaf: Boolean = true
-      override def asLeaf: Result[Json] = encoder(focus).rightIor
-    }
-
-    def deriveLeafCursorBuilder[T](tpe0: Type)(implicit encoder: Encoder[T]): CursorBuilder[T] =
-      new CursorBuilder[T] {
-        val tpe = tpe0
-        def build(context: Context, focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
-          new LeafCursor(context.asType(tpe), focus, encoder, parent, env).rightIor
-      }
-
-    implicit def leafCursorBuilder[T](implicit encoder: Encoder[T]): CursorBuilder[T] =
-      deriveLeafCursorBuilder(StringType)
-  }
-
-  abstract class PrimitiveCursor[T] extends AbstractCursor {
-    val focus: T
-    override def isLeaf: Boolean = true
   }
 }

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -46,15 +46,19 @@ object StarWarsData {
         ids.traverse(id => characters.find(_.id == id).toRightIor(mkOneError(s"Bad id '$id'"))).map(_.some)
     }
 
+  case class Planet(value: String)
+
   case class Human(
     id: String,
     name: Option[String],
     appearsIn: Option[List[Episode.Value]],
     friends: Option[List[String]],
-    homePlanet: Option[String]
+    homePlanet: Option[Planet]
   ) extends Character
 
   object Human {
+    implicit val planetCursorBuilder: CursorBuilder[Planet] =
+      CursorBuilder[String].contramap(_.value)
     implicit val cursorBuilder: CursorBuilder[Human] =
       deriveObjectCursorBuilder[Human](HumanType)
         .transformField("friends")(resolveFriends)
@@ -80,14 +84,14 @@ object StarWarsData {
       name = Some("Luke Skywalker"),
       friends = Some(List("1002", "1003", "2000", "2001")),
       appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
-      homePlanet = Some("Tatooine")
+      homePlanet = Some(Planet("Tatooine"))
     ),
     Human(
       id = "1001",
       name = Some("Darth Vader"),
       friends = Some(List("1004")),
       appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
-      homePlanet = Some("Tatooine")
+      homePlanet = Some(Planet("Tatooine"))
     ),
     Human(
       id = "1002",
@@ -101,7 +105,7 @@ object StarWarsData {
       name = Some("Leia Organa"),
       friends = Some(List("1000", "1002", "2000", "2001")),
       appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
-      homePlanet = Some("Alderaan")
+      homePlanet = Some(Planet("Alderaan"))
     ),
     Human(
       id = "1004",

--- a/modules/generic/src/test/scala/effects.scala
+++ b/modules/generic/src/test/scala/effects.scala
@@ -27,14 +27,13 @@ class GenericEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends Gener
       }
     """
 
-  val QueryType  = schema.ref("Query")
+  val QueryType = schema.ref("Query")
   val StructType = schema.ref("Struct")
 
-  case class Wrapper(value: Int)
-  case class Struct(n: Wrapper, s: String)
+  case class Struct(n: Int, s: String)
   object Struct {
-    implicit val wrappedCb: CursorBuilder[Wrapper]    = CursorBuilder[Int].contramap(_.value)
-    implicit val cursorBuilder: CursorBuilder[Struct] = deriveObjectCursorBuilder[Struct](StructType)
+    implicit val cursorBuilder: CursorBuilder[Struct] =
+      deriveObjectCursorBuilder[Struct](StructType)
   }
 
   val typeMappings = List(
@@ -45,7 +44,7 @@ class GenericEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends Gener
           // Compute a ValueCursor
           RootEffect.computeCursor("foo")((_, p, e) =>
             ref.update(_+1).as(
-              genericCursor(p, e, Struct(Wrapper(42), "hi"))
+              genericCursor(p, e, Struct(42, "hi"))
             )
           )
         )
@@ -77,13 +76,15 @@ final class GenericEffectSpec extends CatsSuite {
 
     val prg: IO[(Json, Int)] =
       for {
-        ref <- SignallingRef[IO, Int](0)
-        map = new GenericEffectMapping(ref)
-        res <- map.compileAndRun(query)
-        eff <- ref.get
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new GenericEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
       } yield (res, eff)
 
     val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
 
     assert(res == expected)
     assert(eff == 1)
@@ -112,13 +113,15 @@ final class GenericEffectSpec extends CatsSuite {
 
     val prg: IO[(Json, Int)] =
       for {
-        ref <- SignallingRef[IO, Int](0)
-        map = new GenericEffectMapping(ref)
-        res <- map.compileAndRun(query)
-        eff <- ref.get
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new GenericEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
       } yield (res, eff)
 
     val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
 
     assert(res == expected)
     assert(eff == 1)


### PR DESCRIPTION
On top of #320, will rebase if that goes in.

We've found this very handy, particularly for leaf nodes and wrappers around standard types (lists, options, etc).

The reason I haven't made it a Cats type class instance is that I wasn't sure if it's lawful? There are some [ContravariantMonoidalLaws](https://github.com/typelevel/cats/blob/main/laws/src/main/scala/cats/laws/ContravariantMonoidalLaws.scala). Maybe it should be called something else 🤷 