### PR TITLE
Handle failing discriminator correctly

### DIFF
--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -73,6 +73,14 @@ final class InterfacesSpec extends DoobieDatabaseSuite with SqlInterfacesSpec {
     }
 }
 
+final class InterfacesSpec2 extends DoobieDatabaseSuite with SqlInterfacesSpec2 {
+  lazy val mapping =
+    new DoobieTestMapping(xa) with SqlInterfacesMapping2[IO] {
+      def entityType: Codec =
+        (Meta[Int].timap(EntityType.fromInt)(EntityType.toInt), false)
+    }
+}
+
 final class JsonbSpec extends DoobieDatabaseSuite with SqlJsonbSpec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlJsonbMapping[IO]
 }

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -73,6 +73,14 @@ final class InterfacesSpec extends SkunkDatabaseSuite with SqlInterfacesSpec {
     }
 }
 
+final class InterfacesSpec2 extends SkunkDatabaseSuite with SqlInterfacesSpec2 {
+  lazy val mapping =
+    new SkunkTestMapping(pool) with SqlInterfacesMapping2[IO] {
+      def entityType: Codec =
+        (codec.int4.imap(EntityType.fromInt)(EntityType.toInt), false)
+    }
+}
+
 final class JsonbSpec extends SkunkDatabaseSuite with SqlJsonbSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlJsonbMapping[IO]
 }

--- a/modules/sql/src/test/scala/SqlInterfacesMapping.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesMapping.scala
@@ -178,7 +178,7 @@ trait SqlInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
       LeafMapping[EntityType](EntityTypeType)
     )
 
-  object entityTypeDiscriminator extends SqlDiscriminator {
+  lazy val entityTypeDiscriminator = new SqlDiscriminator {
     def discriminate(c: Cursor): Result[Type] = {
       for {
         et <- c.fieldAs[EntityType]("entityType")

--- a/modules/sql/src/test/scala/SqlInterfacesMapping2.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesMapping2.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import edu.gemini.grackle._
+import Predicate._
+
+trait SqlInterfacesMapping2[F[_]] extends SqlInterfacesMapping[F] { self =>
+
+  override lazy val entityTypeDiscriminator = new SqlDiscriminator {
+
+    // discriminator always fails
+    def discriminate(c: Cursor): Result[Type] =
+      Result.failure("no")
+
+    // same as in SqlInterfacesMapping
+    def narrowPredicate(subtpe: Type): Option[Predicate] = {
+      def mkPredicate(tpe: EntityType): Option[Predicate] =
+        Some(Eql(EType / "entityType", Const(tpe)))
+
+      subtpe match {
+        case FilmType => mkPredicate(EntityType.Film)
+        case SeriesType => mkPredicate(EntityType.Series)
+        case _ => None
+      }
+    }
+  }
+
+}

--- a/modules/sql/src/test/scala/SqlInterfacesSpec2.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesSpec2.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlInterfacesSpec2 extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("when discriminator fails the fragments should be ignored") {
+    val query = """
+      query {
+        entities {
+          id
+          entityType
+          title
+          ... on Film {
+            rating
+          }
+          ... on Series {
+            numberOfEpisodes
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "1",
+              "entityType" : "FILM",
+              "title" : "Film 1"
+            },
+            {
+              "id" : "2",
+              "entityType" : "FILM",
+              "title" : "Film 2"
+            },
+            {
+              "id" : "3",
+              "entityType" : "FILM",
+              "title" : "Film 3"
+            },
+            {
+              "id" : "4",
+              "entityType" : "SERIES",
+              "title" : "Series 1"
+            },
+            {
+              "id" : "5",
+              "entityType" : "SERIES",
+              "title" : "Series 2"
+            },
+            {
+              "id" : "6",
+              "entityType" : "SERIES",
+              "title" : "Series 3"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
@milessabin this is the condition I was talking about earlier

Here I have created a subtype of `SqlInterfacesMapping` where the discriminator always fails, which should cause all type conditions to fail. Instead it causes all type conditions to succeed.

```graphql
query {
  entities {
    id
    entityType
    title
    ... on Film {
      rating
    }
    ... on Series {
      numberOfEpisodes
    }
  }
}
```

Should result in each result having only the common properties. Instead each result has both!

```json
{
  "data" : {
    "entities" : [
      {
        "id" : "4",
        "entityType" : "SERIES",
        "title" : "Series 1",
        "rating" : null,
        "numberOfEpisodes" : 5
      },
      {
        "id" : "5",
        "entityType" : "SERIES",
        "title" : "Series 2",
        "rating" : null,
        "numberOfEpisodes" : 6
      },
      {
        "id" : "2",
        "entityType" : "FILM",
        "title" : "Film 2",
        "rating" : "U",
        "numberOfEpisodes" : null
      },
      {
        "id" : "3",
        "entityType" : "FILM",
        "title" : "Film 3",
        "rating" : "15",
        "numberOfEpisodes" : null
      },
      ....
```
