### PR TITLE
error extension

### DIFF
--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -10,7 +10,8 @@ import io.circe.syntax._
 final case class Problem(
   message: String,
   locations: List[(Int, Int)] = Nil,
-  path: List[String] = Nil
+  path: List[String] = Nil,
+  extension: Option[JsonObject] = None,
 ) {
 
   override def toString = {
@@ -23,12 +24,14 @@ final case class Problem(
         if (a == b) a.toString else s"$a..$b"
       } .mkString(", ")
 
-    (path.nonEmpty, locations.nonEmpty) match {
+    val s = (path.nonEmpty, locations.nonEmpty) match {
       case (true, true)   => s"$message (at $pathText: $locationsText)"
       case (true, false)  => s"$message (at $pathText)"
       case (false, true)  => s"$message (at $locationsText)"
       case (false, false) => message
     }
+
+    extension.fold(s)(obj => s"$s, extension: ${obj.asJson.spaces2}")
 
   }
 
@@ -54,10 +57,14 @@ object Problem {
       if (p.path.isEmpty) Nil
       else List(("path" -> p.path.asJson))
 
+    val extensionField: List[(String, Json)] =
+      p.extension.fold(List.empty[(String, Json)])(obj => List("extension" -> obj.asJson))
+
     Json.fromFields(
       "message" -> p.message.asJson ::
       locationsField                :::
-      pathField
+      pathField                     :::
+      extensionField
     )
 
   }

--- a/modules/core/src/test/scala/compiler/ProblemSpec.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSpec.scala
@@ -7,6 +7,7 @@ import cats.tests.CatsSuite
 import edu.gemini.grackle.syntax._
 import edu.gemini.grackle.Problem
 import io.circe.syntax._
+import io.circe.JsonObject
 
 final class ProblemSpec extends CatsSuite {
 
@@ -103,6 +104,24 @@ final class ProblemSpec extends CatsSuite {
   test("toString (message only)") {
     assert(
       Problem("foo", Nil, Nil).toString == "foo"
+    )
+  }
+
+  test("extension") {
+    val p = Problem("foo", extension = Some(JsonObject("bar" -> 42.asJson, "baz" -> List("a", "b").asJson)))
+    assert(
+      p.asJson == json"""
+        {
+          "message" : "foo",
+          "extension" : {
+            "bar" : 42,
+            "baz" : [
+              "a",
+              "b"
+            ]
+          }
+        }
+      """
     )
   }
 


### PR DESCRIPTION
This adds an optional `extension` member (a `JsonObject`, as a map is required by the spec) to `Problem` as support for error extensions described in [§7.1.2](https://spec.graphql.org/October2021/#sec-Errors.Error-result-format).