### PR TITLE
Add Ast.Document literals

### DIFF
--- a/modules/core/src/main/scala-3/syntax3.scala
+++ b/modules/core/src/main/scala-3/syntax3.scala
@@ -5,6 +5,8 @@ package edu.gemini.grackle
 
 import cats.syntax.all._
 import org.typelevel.literally.Literally
+import edu.gemini.grackle.Ast.Document
+import edu.gemini.grackle.GraphQLParser.Document.parseAll
 import edu.gemini.grackle.Schema
 import io.circe.Json
 import io.circe.parser.parse
@@ -14,6 +16,7 @@ trait VersionSpecificSyntax:
   extension (inline ctx: StringContext)
     inline def schema(inline args: Any*): Schema = ${SchemaLiteral('ctx, 'args)}
     inline def json(inline args: Any*): Json = ${JsonLiteral('ctx, 'args)}
+    inline def doc(inline args: Any*): Document = ${ DocumentLiteral('ctx, 'args) }
 
 object SchemaLiteral extends Literally[Schema]:
   def validate(s: String)(using Quotes) =
@@ -27,4 +30,11 @@ object JsonLiteral extends Literally[Json]:
     parse(s).bimap(
       pf => s"Invalid JSON: ${pf.message}",
       _  => '{parse(${Expr(s)}).toOption.get}
+    )
+
+object DocumentLiteral extends Literally[Document]:
+  def validate(s: String)(using Quotes) =
+    parseAll(s).bimap(
+      pf => show"Invalid document: $pf",
+      _ => '{parseAll(${Expr(s)}).toOption.get}
     )

--- a/modules/core/src/test/scala/parser/ParserSpec.scala
+++ b/modules/core/src/test/scala/parser/ParserSpec.scala
@@ -6,11 +6,12 @@ package parser
 import cats.tests.CatsSuite
 
 import edu.gemini.grackle.{ Ast, GraphQLParser }
+import edu.gemini.grackle.syntax._
 import Ast._, OperationType._, OperationDefinition._, Selection._, Value._, Type.Named
 
 final class ParserSuite extends CatsSuite {
   test("simple query") {
-    val query = """
+    val query = doc"""
       query {
         character(id: 1000) {
           name
@@ -29,10 +30,7 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseAll(query).toOption match {
-      case Some(List(q)) => assert(q == expected)
-      case _ => assert(false)
-    }
+    assert(query == List(expected))
   }
 
   test("multiple parameters (commas)") {


### PR DESCRIPTION
The error messages are pretty incomprehensible despite using the `Show` instance from cats parser. 

Shall I change all the parser tests to use the literal or is this alright as a quick sanity check?