### PR TITLE
Adds Directives.isRepeatable to introspection response

### DIFF
--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -88,6 +88,7 @@ object Introspection {
           description: String
           locations: [__DirectiveLocation!]!
           args: [__InputValue!]!
+          isRepeatable: Boolean!
         }
 
         enum __DirectiveLocation {
@@ -259,7 +260,8 @@ object Introspection {
               ValueField("name", _.name),
               ValueField("description", _.description),
               ValueField("locations", _.locations),
-              ValueField("args", _.args)
+              ValueField("args", _.args),
+              ValueField("isRepeatable", _.isRepeatable)
             )
         ),
         LeafMapping[TypeKind.Value](__TypeKindType)

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -854,7 +854,8 @@ case class Directive(
   name: String,
   description: Option[String],
   locations: List[Ast.DirectiveLocation],
-  args: List[InputValue]
+  args: List[InputValue],
+  isRepeatable: Boolean
 )
 
 /**

--- a/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
@@ -876,6 +876,7 @@ final class IntrospectionSuite extends CatsEffectSuite {
       |      args {
       |        ...InputValue
       |      }
+      |      isRepeatable
       |    }
       |  }
       |}


### PR DESCRIPTION
Although at the moment the directives return an empty array, we need to be able to parse a query that asks for all the fields required in the spec, specifically isRepeatable

https://spec.graphql.org/draft/#sec-The-__Directive-Type
https://github.com/graphql/graphql-spec/blame/main/spec/Section%204%20--%20Introspection.md#L500-L502