### PR TITLE
`extension` -> `extensions`

### DIFF
--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -12,7 +12,7 @@ final case class Problem(
   message: String,
   locations: List[(Int, Int)] = Nil,
   path: List[String] = Nil,
-  extension: Option[JsonObject] = None,
+  extensions: Option[JsonObject] = None,
 ) {
 
   override def toString = {
@@ -32,7 +32,7 @@ final case class Problem(
       case (false, false) => message
     }
 
-    extension.fold(s)(obj => s"$s, extension: ${obj.asJson.spaces2}")
+    extensions.fold(s)(obj => s"$s, extensions: ${obj.asJson.spaces2}")
 
   }
 
@@ -58,14 +58,14 @@ object Problem {
       if (p.path.isEmpty) Nil
       else List(("path" -> p.path.asJson))
 
-    val extensionField: List[(String, Json)] =
-      p.extension.fold(List.empty[(String, Json)])(obj => List("extension" -> obj.asJson))
+    val extensionsField: List[(String, Json)] =
+      p.extensions.fold(List.empty[(String, Json)])(obj => List("extensions" -> obj.asJson))
 
     Json.fromFields(
       "message" -> p.message.asJson ::
       locationsField                :::
       pathField                     :::
-      extensionField
+      extensionsField
     )
 
   }

--- a/modules/core/src/test/scala/compiler/ProblemSuite.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSuite.scala
@@ -109,12 +109,12 @@ final class ProblemSuite extends CatsEffectSuite {
   }
 
   test("extension") {
-    val p = Problem("foo", extension = Some(JsonObject("bar" -> 42.asJson, "baz" -> List("a", "b").asJson)))
+    val p = Problem("foo", extensions = Some(JsonObject("bar" -> 42.asJson, "baz" -> List("a", "b").asJson)))
     assertEquals(
       p.asJson, json"""
         {
           "message" : "foo",
-          "extension" : {
+          "extensions" : {
             "bar" : 42,
             "baz" : [
               "a",


### PR DESCRIPTION
I'm a little confused if this was an oversight in https://github.com/gemini-hlsw/gsp-graphql/pull/375 but according to the spec I believe this field should be rendered as `extensions`.

https://spec.graphql.org/October2021/#sec-Errors.Error-result-format