### PR TITLE
Restore Scala.js and Native plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("de.heikoseeberger"         % "sbt-header"                    % "5.
 addSbtPlugin("pl.project13.scala"        % "sbt-jmh"                       % "0.4.6")
 addSbtPlugin("nl.zolotko.sbt"            % "sbt-jfr"                       % "0.0.1")
 addSbtPlugin("com.eed3si9n"              % "sbt-buildinfo"                 % "0.11.0")
+addSbtPlugin("org.scala-js"              % "sbt-scalajs"                   % "1.13.2")
+addSbtPlugin("org.scala-native"          % "sbt-scala-native"              % "0.4.15")


### PR DESCRIPTION
These were removed by mistake in https://github.com/gemini-hlsw/gsp-graphql/pull/458. See:
- https://typelevel.org/sbt-typelevel/faq.html#how-do-i-manage-my-scala-js-and-scala-native-versions