### PR TITLE
Update Native to v0.5 and Skunk to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: grackle-demo_2.13 grackle-demo_3 benchmarks_2.13 benchmarks_3 rootjs_2.13 rootjs_3 docs_2.13 docs_3 buildinfo_native0.4_2.13 buildinfo_native0.4_3 buildinfo_sjs1_2.13 buildinfo_sjs1_3 profile_2.13 profile_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 buildinfo_2.13 buildinfo_3 repodocs_2.13 repodocs_3
+          modules-ignore: grackle-demo_2.13 grackle-demo_3 benchmarks_2.13 benchmarks_3 rootjs_2.13 rootjs_3 docs_2.13 docs_3 buildinfo_native0.5_2.13 buildinfo_native0.5_3 buildinfo_sjs1_2.13 buildinfo_sjs1_3 profile_2.13 profile_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 buildinfo_2.13 buildinfo_3 repodocs_2.13 repodocs_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   coverage:

--- a/build.sbt
+++ b/build.sbt
@@ -2,28 +2,28 @@ import nl.zolotko.sbt.jfr.{JfrRecording, JfrRecorderOptions}
 import scala.concurrent.duration.DurationInt
 import scala.sys.process._
 
-val catsVersion            = "2.11.0"
-val catsParseVersion       = "1.0.0"
+val catsVersion            = "2.13.0"
+val catsParseVersion       = "1.1.0"
 val catsEffectVersion      = "3.7.0"
-val circeVersion           = "0.14.8"
-val disciplineMunitVersion = "2.0.0-M3"
+val circeVersion           = "0.14.15"
+val disciplineMunitVersion = "2.0.0"
 val doobieVersion          = "1.0.0-RC12"
-val fs2Version             = "3.12.2"
-val http4sVersion          = "0.23.33"
+val fs2Version             = "3.13.0"
+val http4sVersion          = "0.23.34"
 val kindProjectorVersion   = "0.13.4"
-val literallyVersion       = "1.1.0"
+val literallyVersion       = "1.2.0"
 val logbackVersion         = "1.5.32"
 val log4catsVersion        = "2.8.0"
 val mssqlDriverVersion     = "13.4.0.jre11"
-val munitVersion           = "1.0.0-M11"
-val munitCatsEffectVersion = "2.1.0"
-val munitScalaCheckVersion = "1.0.0-M11"
+val munitVersion           = "1.3.0"
+val munitCatsEffectVersion = "2.2.0"
+val munitScalaCheckVersion = "1.3.0"
 val oracleDriverVersion    = "23.26.1.0.0"
-val skunkVersion           = "0.6.5"
-val shapeless2Version      = "2.3.11"
-val shapeless3Version      = "3.4.1"
-val sourcePosVersion       = "1.1.0"
-val typenameVersion        = "1.1.0"
+val skunkVersion           = "1.0.0"
+val shapeless2Version      = "2.3.13"
+val shapeless3Version      = "3.5.0"
+val sourcePosVersion       = "1.2.0"
+val typenameVersion        = "1.1.2"
 
 val Scala2 = "2.13.18"
 val Scala3 = "3.3.7"
@@ -40,7 +40,7 @@ ThisBuild / developers       := List(
   Developer("tpolecat",   "Rob Norris",  "rnorris@gemini.edu",   url("http://www.tpolecat.org")),
 )
 
-ThisBuild / tlFatalWarnings         := true
+ThisBuild / tlFatalWarnings         := sys.env.contains("CI")
 ThisBuild / tlCiScalafmtCheck       := false
 ThisBuild / tlCiReleaseBranches     := Seq("main")
 ThisBuild / githubWorkflowBuild     ~= { steps =>
@@ -136,6 +136,14 @@ lazy val commonSettings = Seq(
   ))
 )
 
+lazy val nativeSettings = Seq(
+  // Native was updated to 0.5 in 0.26.1
+  tlVersionIntroduced := Map(
+    "2.13" -> "0.26.1",
+    "3" -> "0.26.1"
+  )
+)
+
 lazy val modules: List[CompositeProject] = List(
   core,
   circe,
@@ -181,6 +189,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0",
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   )
+  .nativeSettings(nativeSettings)
 
 lazy val circe = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -192,6 +201,7 @@ lazy val circe = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "grackle-circe",
   )
+  .nativeSettings(nativeSettings)
 
 lazy val buildInfo = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -201,6 +211,7 @@ lazy val buildInfo = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     buildInfoKeys += "baseDirectory" -> (LocalRootProject / baseDirectory).value.toString
   )
+  .nativeSettings(nativeSettings)
 
 lazy val sqlcore = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -216,6 +227,7 @@ lazy val sqlcore = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "co.fs2"            %%% "fs2-io"             % fs2Version % "test",
     )
   )
+  .nativeSettings(nativeSettings)
 
 lazy val sqlpg = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Full)
@@ -227,6 +239,7 @@ lazy val sqlpg = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "grackle-sql-pg",
   )
+  .nativeSettings(nativeSettings)
 
 lazy val doobiecore = project
   .in(file("modules/doobie-core"))
@@ -319,6 +332,7 @@ lazy val skunk = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   )
+  .nativeSettings(nativeSettings)
 
 lazy val generic = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -335,6 +349,7 @@ lazy val generic = crossProject(JVMPlatform, JSPlatform, NativePlatform)
         case Scala2 => "com.chuusai"   %%% "shapeless"           % shapeless2Version
       })
   )
+  .nativeSettings(nativeSettings)
 
 import spray.revolver.Actions._
 

--- a/modules/skunk/js-jvm/src/test/scala/SkunkDatabaseSuite.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkDatabaseSuite.scala
@@ -21,7 +21,10 @@ import java.util.UUID
 import cats.effect.{IO, Resource, Sync}
 import io.circe.{Decoder => CDecoder, Encoder => CEncoder, Json}
 import munit.catseffect.IOFixture
-import natchez.Trace.Implicits.noop
+import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.metrics.Meter.Implicits.noop as metricsNoop
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 import skunk.{ Codec => SCodec, Session }
 import skunk.codec.{ all => codec }
 import skunk.circe.codec.{ all => ccodec }
@@ -33,19 +36,20 @@ import grackle.sqlpg.test._
 
 trait SkunkDatabaseSuite extends SqlPgDatabaseSuite {
 
+  implicit val meter: Meter[IO] = metricsNoop[IO]
+  implicit val tracer: Tracer[IO] = noop[IO]
+
   def poolResource: Resource[IO, Resource[IO, Session[IO]]] = {
     val connInfo = postgresConnectionInfo
     import connInfo._
 
-    Session.pooled[IO](
-      host     = host,
-      port     = port,
-      user     = username,
-      password = Some(password),
-      database = databaseName,
-      max      = 3,
-      //debug    = true,
-    )
+    Session.Builder[IO]
+      .withHost(host)
+      .withPort(port)
+      .withUserAndPassword(username, password)
+      .withDatabase(databaseName)
+      // .withDebug(true)
+      .pooled(max = 3)
   }
 
   val poolFixture: IOFixture[Resource[IO, Session[IO]]] = ResourceSuiteLocalFixture("skunk", poolResource)
@@ -81,9 +85,9 @@ trait SkunkDatabaseSuite extends SqlPgDatabaseSuite {
     def nullable[T](c: TestCodec[T]): TestCodec[T] = (c._1.opt, true).asInstanceOf[TestCodec[T]]
 
     def list[T: CDecoder : CEncoder](c: TestCodec[T]): TestCodec[List[T]] = {
-      val cc = c._1.asInstanceOf[SCodec[Any]]
+      val cc = c._1
       val ty = _root_.skunk.data.Type(s"_${cc.types.head.name}", cc.types)
-      val encode = (elem: Any) => cc.encode(elem).head.get
+      val encode = (elem: T) => cc.encode(elem).head.get.value
       val decode = (str: String) => cc.decode(0, List(Some(str))).left.map(_.message)
       (SCodec.array(encode, decode, ty), false).asInstanceOf[TestCodec[List[T]]]
     }

--- a/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
@@ -19,6 +19,7 @@ import cats.effect.{IO, Resource}
 import munit.catseffect.IOFixture
 import skunk.Session
 import skunk.codec.{all => codec}
+import skunk.data.Encoded
 import skunk.implicits._
 
 import grackle.skunk.SkunkMonitor
@@ -232,6 +233,8 @@ final class WorldCompilerSuite extends SkunkDatabaseSuite with SqlWorldCompilerS
     "SELECT city.id, city.name FROM city WHERE (city.name ILIKE $1)"
 
   def filterArg: String = "Linh%"
+
+  override def encodeArg(arg: String): Any = Encoded(arg)
 }
 
 // Needed to avoid an unused import warning in Scala 3.3.0+

--- a/modules/sql-core/src/test/scala/SqlWorldCompilerSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlWorldCompilerSuite.scala
@@ -40,6 +40,8 @@ trait SqlWorldCompilerSuite extends CatsEffectSuite {
 
   def filterArg: String
 
+  def encodeArg(arg: String): Any = arg
+
   test("simple restricted query") {
 
     val query =
@@ -78,7 +80,7 @@ trait SqlWorldCompilerSuite extends CatsEffectSuite {
           SqlStatsMonitor.SqlStats(
             Select("country", Unique(Filter(Eql(schema.ref("Country") / "code",Const("GBR")), Select("name")))),
             simpleRestrictedQuerySql,
-            List("GBR"),
+            List(encodeArg("GBR")),
             1,
             2
           )
@@ -133,7 +135,7 @@ trait SqlWorldCompilerSuite extends CatsEffectSuite {
           SqlStatsMonitor.SqlStats(
             Select("cities", Filter(Like(schema.ref("City") / "name","Linh%",true), Select("name"))),
             simpleFilteredQuerySql,
-            List(filterArg),
+            List(encodeArg(filterArg)),
             3,
             2
           )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("pl.project13.scala"        % "sbt-jmh"                       % "0.
 addSbtPlugin("nl.zolotko.sbt"            % "sbt-jfr"                       % "0.0.1")
 addSbtPlugin("com.eed3si9n"              % "sbt-buildinfo"                 % "0.13.1")
 addSbtPlugin("org.scala-js"              % "sbt-scalajs"                   % "1.21.0")
-addSbtPlugin("org.scala-native"          % "sbt-scala-native"              % "0.4.17")
+addSbtPlugin("org.scala-native"          % "sbt-scala-native"              % "0.5.11")
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"                 % "2.4.4")
 addSbtPlugin("com.github.sbt"            % "sbt-unidoc"                    % "0.6.1")


### PR DESCRIPTION
And some other minor library updates.
Since Skunk 1 is only published to Native 0.5, there's no way to do these separately.