### PR TITLE
Fix (-1, 0) numeric parsing

### DIFF
--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -328,12 +328,16 @@ object GraphQLParser {
         Ast.Value.FloatValue(d.toDouble)
 
       token(
-        (intLiteral ~ (char('.') *> digit.rep.string).? ~ ((char('e') | char('E')) *> intLiteral.string).?)
+        // Keep the integer part as its raw matched text (via `.string`) so that a
+        // negative sign on a zero integer part (e.g. `-0.99`) is preserved. Parsing
+        // it to an `Int` first would collapse `-0` to `0`, dropping the sign for any
+        // value in (-1, 0).
+        (intLiteral.string ~ (char('.') *> digit.rep.string).? ~ ((char('e') | char('E')) *> intLiteral.string).?)
           .map {
             case ((a, Some(b)), None) => narrow(BigDecimal(s"$a.$b"))
             case ((a, None), Some(c)) => narrow(BigDecimal(s"${a}E$c"))
             case ((a, Some(b)), Some(c)) => narrow(BigDecimal(s"$a.${b}E$c"))
-            case ((a, None), None) => Ast.Value.IntValue(a)
+            case ((a, None), None) => Ast.Value.IntValue(a.toInt)
           }
       )
     }

--- a/modules/core/src/test/scala/parser/ParserSuite.scala
+++ b/modules/core/src/test/scala/parser/ParserSuite.scala
@@ -564,6 +564,12 @@ final class ParserSuite extends CatsEffectSuite {
     assertParse("123E2", FloatValue(123E2d))
     assertParse("123.2E2", FloatValue(123.2E2d))
 
+    // Negative values whose integer part is zero must retain their sign.
+    assertParse("-0.99", FloatValue(-0.99d))
+    assertParse("-0.5", FloatValue(-0.5d))
+    assertParse("-1.5", FloatValue(-1.5d))
+    assertParse("-0.5E2", FloatValue(-0.5E2d))
+
     assertParse("123", IntValue(123))
     assertParse("-123", IntValue(-123))
 


### PR DESCRIPTION
The `NumericLiteral` parser parsed the integer part as an `Int`, so for example for -0.99 the integer part -0 collapsed to 0, then the float was rebuilt from s"$a.$b" = "0.99".

The fix consists on capturing the integer part as a matched text instead of an int, thus keeping the negative sign.