### PR TITLE
Fix accumulation of used variables in input objects

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -424,7 +424,7 @@ class QueryCompiler(parser: QueryParser, schema: Schema, phases: List[Phase]) {
           else
             values.next() match {
               case VariableRef(nme) =>
-                loop(values, Set(nme))
+                loop(values, vars + nme)
               case ObjectValue(fields) =>
                 loop(fields.iterator.map(_._2) ++ values, vars)
               case ListValue(elems) =>

--- a/modules/core/src/test/scala/compiler/VariablesSuite.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSuite.scala
@@ -587,6 +587,29 @@ final class VariablesSuite extends CatsEffectSuite {
     assertEquals(compiled, Result.success(expected))
   }
 
+  test("multiple variables used in one input object are all detected as used") {
+    val query = """
+      query doSearch($name: String, $age: Int, $id: ID) {
+        search(pattern: { name: $name, age: $age, id: $id }) {
+          name
+          id
+        }
+      }
+    """
+
+    val variables = json"""
+      {
+        "name": "Foo",
+        "age": 23,
+        "id": "123"
+      }
+    """
+
+    val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
+
+    assertEquals(compiled.toProblems.toList, List.empty[Problem])
+  }
+
   test("oneOf variables") {
     val query = """
       query oneOfTest($input: OneOfInObj!) {


### PR DESCRIPTION
In `QueryCompiler.validateVariablesAndFragments`, only the last variable used in an input object was returned as used, it was not accumulating them in the recursion.