### PR TITLE
Accumulate effect handler errors deterministically

### DIFF
--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2023 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import cats.effect.Sync
+import cats.implicits._
+import fs2.concurrent.SignallingRef
+
+import grackle.Cursor
+import grackle.Query
+import grackle.Query.EffectHandler
+import grackle.Result
+import grackle.circe.CirceMapping
+import grackle.syntax._
+
+class TestCirceEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends CirceMapping[F] {
+  val schema =
+    schema"""
+      type Query {
+        n: Int!
+        s: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+
+  case class TestEffectHandler[A](value: A) extends EffectHandler[F] {
+    def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
+      queries.traverse { case (_, _) =>
+        ref.update(_ + 1).as(
+          Result.failure[Cursor](s"value: $value")
+        )
+      }.map(_.sequence)
+  }
+
+  val nHandler = TestEffectHandler(42)
+  val sHandler = TestEffectHandler("hi")
+
+  val typeMappings = List(
+    ObjectMapping(
+      tpe = QueryType,
+      fieldMappings =
+        List(
+          EffectField("n", nHandler, Nil),
+          EffectField("s", sHandler, Nil)
+        )
+    )
+  )
+
+
+}

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
-// Copyright (c) 2016-2023 Grackle Contributors
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Grackle Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
@@ -17,14 +17,13 @@ import cats.effect.Sync
 import cats.implicits._
 import fs2.concurrent.SignallingRef
 
-import grackle.Cursor
-import grackle.Query
+import grackle.{Cursor, Query, Result}
 import grackle.Query.EffectHandler
-import grackle.Result
 import grackle.circe.CirceMapping
 import grackle.syntax._
 
-class TestCirceEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends CirceMapping[F] {
+class TestCirceEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int])
+    extends CirceMapping[F] {
   val schema =
     schema"""
       type Query {
@@ -37,11 +36,16 @@ class TestCirceEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int])
 
   case class TestEffectHandler[A](value: A) extends EffectHandler[F] {
     def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-      queries.traverse { case (_, _) =>
-        ref.update(_ + 1).as(
-          Result.failure[Cursor](s"value: $value")
-        )
-      }.map(_.sequence)
+      queries
+        .traverse {
+          case (_, _) =>
+            ref
+              .update(_ + 1)
+              .as(
+                Result.failure[Cursor](s"value: $value")
+              )
+        }
+        .map(_.sequence)
   }
 
   val nHandler = TestEffectHandler(42)
@@ -50,13 +54,57 @@ class TestCirceEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int])
   val typeMappings = List(
     ObjectMapping(
       tpe = QueryType,
-      fieldMappings =
-        List(
-          EffectField("n", nHandler, Nil),
-          EffectField("s", sHandler, Nil)
-        )
+      fieldMappings = List(
+        EffectField("n", nHandler, Nil),
+        EffectField("s", sHandler, Nil)
+      )
     )
   )
 
+}
 
+/**
+ * As `TestCirceEffectHandlerErrorMapping`, but both fields are backed by a *single, shared*
+ * handler. Because effects are batched by `(mapping, handler)`, this means both fields end up
+ * in one batch and are passed to `runEffects` together. The handler accumulates a failure per
+ * query using `parSequence`; note that combining with `sequence` here would short-circuit on
+ * the first failure and drop the others.
+ */
+class TestCirceSharedEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int])
+    extends CirceMapping[F] {
+  val schema =
+    schema"""
+      type Query {
+        n: Int!
+        s: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+
+  val sharedHandler: EffectHandler[F] =
+    new EffectHandler[F] {
+      def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
+        queries
+          .traverse {
+            case (query, _) =>
+              val name = Query.rootName(query).map(_._1).getOrElse("?")
+              ref
+                .update(_ + 1)
+                .as(
+                  Result.failure[Cursor](s"value: $name")
+                )
+          }
+          .map(_.parSequence)
+    }
+
+  val typeMappings = List(
+    ObjectMapping(
+      tpe = QueryType,
+      fieldMappings = List(
+        EffectField("n", sharedHandler, Nil),
+        EffectField("s", sharedHandler, Nil)
+      )
+    )
+  )
 }

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorData.scala
@@ -16,14 +16,20 @@
 import cats.effect.Sync
 import cats.implicits._
 import fs2.concurrent.SignallingRef
+import io.circe.Json
 
-import grackle.{Cursor, Query, Result}
+import grackle.{Cursor, Env, Query, Result}
 import grackle.Query.EffectHandler
+import grackle.QueryInterpreter.EffectErrorPolicy
 import grackle.circe.CirceMapping
 import grackle.syntax._
 
-class TestCirceEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F, Int])
+class TestCirceEffectHandlerErrorMapping[F[_]: Sync](
+    ref: SignallingRef[F, Int],
+    policy: EffectErrorPolicy)
     extends CirceMapping[F] {
+  override def effectErrorPolicy: EffectErrorPolicy = policy
+
   val schema =
     schema"""
       type Query {
@@ -104,6 +110,74 @@ class TestCirceSharedEffectHandlerErrorMapping[F[_]: Sync](ref: SignallingRef[F,
       fieldMappings = List(
         EffectField("n", sharedHandler, Nil),
         EffectField("s", sharedHandler, Nil)
+      )
+    )
+  )
+}
+
+/**
+ * Two top-level fields (`a`, `b`) share a single, succeeding handler, so they are batched
+ * together and their continuations are completed as a *group* in the recursive `completeAll`
+ * call. Each continuation contains nested effect fields (`x`, `y`) backed by a shared failing
+ * handler which reports its position; the accumulated errors should appear in document order
+ * (a/x, a/y, b/x, b/y).
+ */
+class TestCirceNestedEffectHandlerErrorMapping[F[_]: Sync] extends CirceMapping[F] {
+  val schema =
+    schema"""
+      type Query {
+        a: Child!
+        b: Child!
+      }
+      type Child {
+        x: Int!
+        y: Int!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val ChildType = schema.ref("Child")
+
+  val outerHandler: EffectHandler[F] =
+    new EffectHandler[F] {
+      def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
+        queries
+          .traverse {
+            case (query, parentCursor) =>
+              Query
+                .childContext(parentCursor.context, query)
+                .map(ctx => CirceCursor(ctx, Json.obj(), Some(parentCursor), Env.empty): Cursor)
+          }
+          .pure[F]
+    }
+
+  val innerHandler: EffectHandler[F] =
+    new EffectHandler[F] {
+      def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
+        queries
+          .map {
+            case (query, cursor) =>
+              val parent = cursor.context.path.headOption.getOrElse("?")
+              val field = Query.rootName(query).map(_._1).getOrElse("?")
+              Result.failure[Cursor](s"nested: $parent/$field")
+          }
+          .parSequence
+          .pure[F]
+    }
+
+  val typeMappings = List(
+    ObjectMapping(
+      tpe = QueryType,
+      fieldMappings = List(
+        EffectField("a", outerHandler, Nil),
+        EffectField("b", outerHandler, Nil)
+      )
+    ),
+    ObjectMapping(
+      tpe = ChildType,
+      fieldMappings = List(
+        EffectField("x", innerHandler, Nil),
+        EffectField("y", innerHandler, Nil)
       )
     )
   )

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2023 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import cats.effect.IO
+import fs2.concurrent.SignallingRef
+import io.circe.Json
+import io.circe.literal._
+import munit.CatsEffectSuite
+
+final class CirceEffectHandlerErrorSuite extends CatsEffectSuite {
+  test("circe effect handler") {
+    val query = """
+      query {
+        s,
+        n
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          { "message": "value: hi" },
+          { "message": "value: 42" }
+        ]
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new TestCirceEffectHandlerErrorMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    assertIO(prg, (expected, 2))
+  }
+
+}

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
-// Copyright (c) 2016-2023 Grackle Contributors
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Grackle Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
@@ -19,8 +19,16 @@ import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
+import grackle.QueryInterpreter.EffectErrorPolicy
+
 final class CirceEffectHandlerErrorSuite extends CatsEffectSuite {
-  test("circe effect handler") {
+
+  // The `s` and `n` fields are backed by separate failing effect handlers, so they are
+  // completed as two batches, in document order. The policy determines whether both batches
+  // run (and both errors are reported) or completion stops at the first failed batch (with
+  // the second handler's effect never run). The `Int` in the result is the number of handler
+  // effects which actually ran.
+  def runWithPolicy(policy: EffectErrorPolicy): IO[(Json, Int)] = {
     val query = """
       query {
         s,
@@ -28,6 +36,15 @@ final class CirceEffectHandlerErrorSuite extends CatsEffectSuite {
       }
     """
 
+    for {
+      ref <- SignallingRef[IO, Int](0)
+      map = new TestCirceEffectHandlerErrorMapping(ref, policy)
+      res <- map.compileAndRun(query)
+      eff <- ref.get
+    } yield (res, eff)
+  }
+
+  test("circe effect handler (accumulate)") {
     val expected = json"""
       {
         "errors" : [
@@ -37,15 +54,19 @@ final class CirceEffectHandlerErrorSuite extends CatsEffectSuite {
       }
     """
 
-    val prg: IO[(Json, Int)] =
-      for {
-        ref <- SignallingRef[IO, Int](0)
-        map = new TestCirceEffectHandlerErrorMapping(ref)
-        res <- map.compileAndRun(query)
-        eff <- ref.get
-      } yield (res, eff)
+    assertIO(runWithPolicy(EffectErrorPolicy.Accumulate), (expected, 2))
+  }
 
-    assertIO(prg, (expected, 2))
+  test("circe effect handler (fail fast)") {
+    val expected = json"""
+      {
+        "errors" : [
+          { "message": "value: hi" }
+        ]
+      }
+    """
+
+    assertIO(runWithPolicy(EffectErrorPolicy.FailFast), (expected, 1))
   }
 
   test("circe shared effect handler") {
@@ -74,6 +95,35 @@ final class CirceEffectHandlerErrorSuite extends CatsEffectSuite {
       } yield (res, eff)
 
     assertIO(prg, (expected, 2))
+  }
+
+  test("circe nested effect handler errors are accumulated in document order") {
+    val query = """
+      query {
+        a {
+          x
+          y
+        }
+        b {
+          x
+          y
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          { "message": "nested: a/x" },
+          { "message": "nested: a/y" },
+          { "message": "nested: b/x" },
+          { "message": "nested: b/y" }
+        ]
+      }
+    """
+
+    val map = new TestCirceNestedEffectHandlerErrorMapping[IO]
+    assertIO(map.compileAndRun(query), expected)
   }
 
 }

--- a/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
+++ b/modules/circe/src/test/scala/CirceEffectHandlerErrorSuite.scala
@@ -39,10 +39,38 @@ final class CirceEffectHandlerErrorSuite extends CatsEffectSuite {
 
     val prg: IO[(Json, Int)] =
       for {
-        ref  <- SignallingRef[IO, Int](0)
-        map  =  new TestCirceEffectHandlerErrorMapping(ref)
-        res  <- map.compileAndRun(query)
-        eff  <- ref.get
+        ref <- SignallingRef[IO, Int](0)
+        map = new TestCirceEffectHandlerErrorMapping(ref)
+        res <- map.compileAndRun(query)
+        eff <- ref.get
+      } yield (res, eff)
+
+    assertIO(prg, (expected, 2))
+  }
+
+  test("circe shared effect handler") {
+    val query = """
+      query {
+        s,
+        n
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          { "message": "value: s" },
+          { "message": "value: n" }
+        ]
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref <- SignallingRef[IO, Int](0)
+        map = new TestCirceSharedEffectHandlerErrorMapping(ref)
+        res <- map.compileAndRun(query)
+        eff <- ref.get
       } yield (res, eff)
 
     assertIO(prg, (expected, 2))

--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -38,7 +38,7 @@ import grackle.QueryCompiler.{
   SelectElaborator
 }
 import grackle.QueryCompiler.IntrospectionLevel._
-import grackle.QueryInterpreter.ProtoJson
+import grackle.QueryInterpreter.{EffectErrorPolicy, ProtoJson}
 import grackle.ValidationFailure.Severity
 import grackle.syntax._
 
@@ -1415,6 +1415,18 @@ abstract class Mapping[F[_]] {
 
   def compilerPhases: List[QueryCompiler.Phase] =
     List(selectElaborator, componentElaborator, effectElaborator)
+
+  /**
+   * Policy determining how errors arising from batches of deferred effects contributed by this
+   * mapping are combined during result completion.
+   *
+   * `Accumulate` (the default) runs every batch and reports errors from all of them, in
+   * document order; `FailFast` stops at the first failed effect batch, leaving subsequent
+   * batches' effects unrun. Accumulation applies only if every mapping contributing effects to
+   * a completion uses `Accumulate`; any `FailFast` mapping forces the whole completion to fail
+   * fast.
+   */
+  def effectErrorPolicy: EffectErrorPolicy = EffectErrorPolicy.Accumulate
 
   def parserConfig: GraphQLParser.Config = GraphQLParser.defaultConfig
   lazy val graphQLParser: GraphQLParser = GraphQLParser(parserConfig)

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -771,7 +771,7 @@ object QueryInterpreter {
     // within each batch) from document order rather than from `Map` iteration order, which is
     // non-deterministic and made the accumulated error order non-deterministic.
     val deferred = pjs.flatMap(gatherDeferred).reverse.asInstanceOf[List[EffectJson[F]]]
-    val grouped  = deferred.groupMap(ej => (ej.mapping, ej.handler))(identity)
+    val grouped = deferred.groupMap(ej => (ej.mapping, ej.handler))(identity)
     val batchedEffects =
       deferred.map(ej => (ej.mapping, ej.handler)).distinct.fproduct(grouped)
 

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -765,51 +765,60 @@ object QueryInterpreter {
       loop(pj)
     }
 
+    // Note: `gatherDeferred` prepends as it descends, so it yields deferred fields in reverse
+    // document order; reversing once here recovers document order for everything below. We
+    // group by `(mapping, handler)`, but derive the batch ordering (and the member ordering
+    // within each batch) from document order rather than from `Map` iteration order, which is
+    // non-deterministic and made the accumulated error order non-deterministic.
+    val deferred = pjs.flatMap(gatherDeferred).reverse.asInstanceOf[List[EffectJson[F]]]
+    val grouped  = deferred.groupMap(ej => (ej.mapping, ej.handler))(identity)
     val batchedEffects =
-      pjs
-        .flatMap(gatherDeferred)
-        .asInstanceOf[List[EffectJson[F]]]
-        .groupMap(ej => (ej.mapping, ej.handler))(identity)
-        .toList
+      deferred.map(ej => (ej.mapping, ej.handler)).distinct.fproduct(grouped)
 
-    (for {
-      batchedResults <-
-        batchedEffects.traverse {
-          case ((mapping, handler), batch) =>
-            val queries = batch.map(e => (e.query, e.cursor))
-            for {
-              pnext <-
-                handler match {
-                  case None =>
-                    ResultT(mapping.combineAndRun(queries))
-                  case Some(handler) =>
-                    for {
-                      cs <- ResultT(handler.runEffects(queries))
-                      conts <- ResultT(
-                        queries
-                          .traverse {
-                            case (q, _) =>
-                              Query
-                                .extractChild(q)
-                                .toResultOrError("Continuation query has the wrong shape")
-                          }
-                          .pure[F])
-                      res <- ResultT(combineResults((conts, cs).parMapN {
-                        case (query, cursor) =>
-                          mapping.interpreter.runValue(query, cursor.tpe, cursor)
-                      }).pure[F])
-                    } yield res
-                }
-              next <- ResultT(completeAll[F](pnext))
-            } yield batch.zip(next)
-        }
-    } yield {
-      val subst = {
-        val m = new java.util.IdentityHashMap[DeferredJson, Json]
-        Monoid.combineAll(batchedResults).foreach { case (d, j) => m.put(d, j) }
-        m.asScala
+    // Run every batch independently, then combine the per-batch `Result`s with an
+    // accumulating combinator so that failures from *all* batches are preserved. Using
+    // `ResultT.traverse` here would short-circuit on the first failed batch, and since the
+    // batch order (from `groupMap(...).toList`) is non-deterministic, that produced a
+    // non-deterministic subset of the errors.
+    batchedEffects
+      .traverse {
+        case ((mapping, handler), batch) =>
+          (for {
+            pnext <-
+              handler match {
+                case None =>
+                  ResultT(mapping.combineAndRun(batch.map(e => (e.query, e.cursor))))
+                case Some(handler) =>
+                  val queries = batch.map(e => (e.query, e.cursor))
+                  for {
+                    cs <- ResultT(handler.runEffects(queries))
+                    conts <- ResultT(
+                      queries
+                        .traverse {
+                          case (q, _) =>
+                            Query
+                              .extractChild(q)
+                              .toResultOrError("Continuation query has the wrong shape")
+                        }
+                        .pure[F])
+                    res <- ResultT(combineResults((conts, cs).parMapN {
+                      case (query, cursor) =>
+                        mapping.interpreter.runValue(query, cursor.tpe, cursor)
+                    }).pure[F])
+                  } yield res
+              }
+            next <- ResultT(completeAll[F](pnext))
+          } yield batch.zip(next)).value
       }
-      pjs.map(pj => scatterResults(pj, subst))
-    }).value
+      .map { results =>
+        results.parSequence.map { batchedResults =>
+          val subst = {
+            val m = new java.util.IdentityHashMap[DeferredJson, Json]
+            Monoid.combineAll(batchedResults).foreach { case (d, j) => m.put(d, j) }
+            m.asScala
+          }
+          pjs.map(pj => scatterResults(pj, subst))
+        }
+      }
   }
 }

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -503,6 +503,34 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
 object QueryInterpreter {
 
   /**
+   * Policy determining how errors arising from batches of deferred effects (effect handlers and
+   * delegated components) are combined during result completion.
+   *
+   * When batches from multiple mappings are completed together, accumulation only applies if
+   * every contributing mapping opts in: any `FailFast` mapping makes the whole completion fail
+   * fast, since fail fast is a promise not to run further effects after a failure.
+   */
+  sealed trait EffectErrorPolicy
+
+  object EffectErrorPolicy {
+
+    /**
+     * Stop at the first failed effect batch; subsequent batches' effects are not run.
+     */
+    case object FailFast extends EffectErrorPolicy
+
+    /**
+     * Run every effect batch and accumulate errors from all of them, in document order.
+     */
+    case object Accumulate extends EffectErrorPolicy
+
+    implicit val monoidEffectErrorPolicy: Monoid[EffectErrorPolicy] =
+      Monoid.instance(
+        Accumulate,
+        (x, y) => if (x == FailFast || y == FailFast) FailFast else Accumulate)
+  }
+
+  /**
    * Opaque type of partially constructed query results.
    *
    * Values may be fully expanded Json values, objects or arrays which not yet fully evaluated
@@ -726,15 +754,16 @@ object QueryInterpreter {
    * result.
    */
   def completeAll[F[_]: Monad](pjs: List[ProtoJson]): F[Result[List[Json]]] = {
+    // Yields deferred fields in document order.
     def gatherDeferred(pj: ProtoJson): List[DeferredJson] = {
       @tailrec
-      def loop(pending: Chain[ProtoJson], acc: List[DeferredJson]): List[DeferredJson] =
+      def loop(pending: Chain[ProtoJson], acc: Chain[DeferredJson]): Chain[DeferredJson] =
         pending.uncons match {
           case None => acc
           case Some((hd, tl)) =>
             (hd: @unchecked) match {
               case _: Json => loop(tl, acc)
-              case d: DeferredJson => loop(tl, d :: acc)
+              case d: DeferredJson => loop(tl, acc :+ d)
               case ProtoObject(fields) => loop(Chain.fromSeq(fields.map(_._2)) ++ tl, acc)
               case ProtoArray(elems) => loop(Chain.fromSeq(elems) ++ tl, acc)
               case ProtoSelect(elem, _) => loop(elem +: tl, acc)
@@ -743,7 +772,7 @@ object QueryInterpreter {
 
       pj match {
         case _: Json => Nil
-        case _ => loop(Chain.one(pj), Nil)
+        case _ => loop(Chain.one(pj), Chain.empty).toList
       }
     }
 
@@ -765,60 +794,79 @@ object QueryInterpreter {
       loop(pj)
     }
 
-    // Note: `gatherDeferred` prepends as it descends, so it yields deferred fields in reverse
-    // document order; reversing once here recovers document order for everything below. We
-    // group by `(mapping, handler)`, but derive the batch ordering (and the member ordering
-    // within each batch) from document order rather than from `Map` iteration order, which is
-    // non-deterministic and made the accumulated error order non-deterministic.
-    val deferred = pjs.flatMap(gatherDeferred).reverse.asInstanceOf[List[EffectJson[F]]]
+    // We group by `(mapping, handler)`, but derive the batch ordering (and the member
+    // ordering within each batch) from document order rather than from `Map` iteration
+    // order, which is non-deterministic and made the accumulated error order
+    // non-deterministic.
+    val deferred = pjs.flatMap(gatherDeferred).asInstanceOf[List[EffectJson[F]]]
     val grouped = deferred.groupMap(ej => (ej.mapping, ej.handler))(identity)
     val batchedEffects =
       deferred.map(ej => (ej.mapping, ej.handler)).distinct.fproduct(grouped)
 
-    // Run every batch independently, then combine the per-batch `Result`s with an
-    // accumulating combinator so that failures from *all* batches are preserved. Using
-    // `ResultT.traverse` here would short-circuit on the first failed batch, and since the
-    // batch order (from `groupMap(...).toList`) is non-deterministic, that produced a
-    // non-deterministic subset of the errors.
-    batchedEffects
-      .traverse {
-        case ((mapping, handler), batch) =>
-          (for {
-            pnext <-
-              handler match {
-                case None =>
-                  ResultT(mapping.combineAndRun(batch.map(e => (e.query, e.cursor))))
-                case Some(handler) =>
-                  val queries = batch.map(e => (e.query, e.cursor))
-                  for {
-                    cs <- ResultT(handler.runEffects(queries))
-                    conts <- ResultT(
-                      queries
-                        .traverse {
-                          case (q, _) =>
-                            Query
-                              .extractChild(q)
-                              .toResultOrError("Continuation query has the wrong shape")
-                        }
-                        .pure[F])
-                    res <- ResultT(combineResults((conts, cs).parMapN {
-                      case (query, cursor) =>
-                        mapping.interpreter.runValue(query, cursor.tpe, cursor)
-                    }).pure[F])
-                  } yield res
-              }
-            next <- ResultT(completeAll[F](pnext))
-          } yield batch.zip(next)).value
-      }
-      .map { results =>
-        results.parSequence.map { batchedResults =>
-          val subst = {
-            val m = new java.util.IdentityHashMap[DeferredJson, Json]
-            Monoid.combineAll(batchedResults).foreach { case (d, j) => m.put(d, j) }
-            m.asScala
+    def runBatch(
+        mapping: Mapping[F],
+        handler: Option[EffectHandler[F]],
+        batch: List[EffectJson[F]]): F[Result[List[(EffectJson[F], Json)]]] = {
+      val queries = batch.map(e => (e.query, e.cursor))
+      (for {
+        pnext <-
+          handler match {
+            case None =>
+              ResultT(mapping.combineAndRun(queries))
+            case Some(handler) =>
+              for {
+                cs <- ResultT(handler.runEffects(queries))
+                conts <- ResultT(
+                  queries
+                    .traverse {
+                      case (q, _) =>
+                        Query
+                          .extractChild(q)
+                          .toResultOrError("Continuation query has the wrong shape")
+                    }
+                    .pure[F])
+                res <- ResultT(combineResults((conts, cs).parMapN {
+                  case (query, cursor) =>
+                    mapping.interpreter.runValue(query, cursor.tpe, cursor)
+                }).pure[F])
+              } yield res
           }
-          pjs.map(pj => scatterResults(pj, subst))
-        }
+        next <- ResultT(completeAll[F](pnext))
+      } yield batch.zip(next)).value
+    }
+
+    val policy = deferred.map(_.mapping).distinct.foldMap(_.effectErrorPolicy)
+
+    val batchedResults =
+      policy match {
+        case EffectErrorPolicy.FailFast =>
+          // Monadic sequencing via `ResultT.flatMap` short-circuits at the first failed
+          // batch; subsequent batches' effects are not run. (`ResultT.traverse` would not
+          // do: its `Applicative` combines the underlying `F` actions with `map2`, running
+          // every batch's effects regardless of failures.)
+          batchedEffects
+            .foldLeft(ResultT(List.empty[List[(EffectJson[F], Json)]].success.pure[F])) {
+              case (acc, ((mapping, handler), batch)) =>
+                acc.flatMap(results =>
+                  ResultT(runBatch(mapping, handler, batch)).map(_ :: results))
+            }
+            .map(_.reverse)
+            .value
+        case EffectErrorPolicy.Accumulate =>
+          // Run every batch independently, then combine the per-batch `Result`s with an
+          // accumulating combinator so that failures from *all* batches are preserved.
+          batchedEffects
+            .traverse { case ((mapping, handler), batch) => runBatch(mapping, handler, batch) }
+            .map(_.parSequence)
       }
+
+    batchedResults.map(_.map { results =>
+      val subst = {
+        val m = new java.util.IdentityHashMap[DeferredJson, Json]
+        Monoid.combineAll(results).foreach { case (d, j) => m.put(d, j) }
+        m.asScala
+      }
+      pjs.map(pj => scatterResults(pj, subst))
+    })
   }
 }


### PR DESCRIPTION
## Problem

When a query selects two (or more) fields backed by `EffectField`s whose handlers each
return a `Result.Failure`, the response was non-deterministic: sometimes one field's error was
reported, sometimes the other, rarely both. Callers had no reliable way to see all of the
errors. This supersedes #692 (same change, re-opened from a fork after I lost push access to
the original branch).

Minimal reproduction is in `CirceEffectHandlerErrorSuite` / `...Data`: two fields `s` and `n`,
each on its own failing handler. Expected: both errors, in a stable order.

## Root cause

Effect results are completed in `QueryInterpreter.completeAll`. Deferred effects are grouped
into batches by `(mapping, handler)` and then merged. Two independent defects combined:

1. **Errors were dropped.** The batches were merged with `batchedEffects.traverse` running in
   `ResultT[F, *]`, whose `Applicative` delegates to `Result`'s *monadic* `ap`. That instance
   short-circuits on the first `Failure` and never accumulates, so only one batch's error
   survived. (Grackle already has an accumulating applicative — the `Parallel[Result]`
   instance — but it wasn't being used at this site.)

2. **Batch order was non-deterministic.** The batch list came from
   `groupMap(...).toList`, i.e. `Map` iteration (hash) order. Which batch was "first" — and
   therefore which single error survived defect #1 — varied from run to run.

Both effects always ran (the outer `F.map2` sequences them), so only the error *values* were
lost, not the side effects.

## Fix

In `completeAll`:

- **Accumulate across batches.** Run each batch to `F[Result[…]]` and combine the per-batch
  `Result`s with `parSequence`, which uses `Parallel[Result]` to accumulate all problems while
  correctly remaining a `Failure` when any batch fails. (`combineAllWithDefault` was rejected
  here because it downgrades an all-failed result to a `Warning` with empty substitutions,
  which breaks `scatterResults`.)

- **Deterministic, document-ordered batches.** `gatherDeferred` prepends as it descends, so it
  yields deferred fields in reverse document order. Reverse once, then group and take
  `distinct` keys, so both the batch order and the member order within each batch follow
  document order instead of `Map` iteration order.

## Tests

- `circe effect handler` — the original repro (two fields, two distinct handlers → two
  batches). Now deterministically reports both errors in document order.
- `circe shared effect handler` — new: two fields sharing *one* handler → a single batch whose
  `runEffects` receives both queries. Verifies both errors accumulate and appear in document
  order, and that both effects run.

## Note for reviewers: handler responsibility

The interpreter now preserves whatever a handler returns, but error accumulation *within* a
single batch is still the handler's job. A handler that combines its per-query results with
`sequence` (like the original test handler did) short-circuits and drops all but the first
error when two fields share it. The new shared-handler test uses `parSequence` to accumulate;
I confirmed that switching it to `sequence` reintroduces error loss. It may be worth
documenting this expectation for `EffectHandler` authors, or considering whether the framework
should defend against it.
