### PR TITLE
Bump tlBaseVersion to 0.29

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / scalaVersion := Scala2
 ThisBuild / crossScalaVersions := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease := Some(11)
 
-ThisBuild / tlBaseVersion := "0.28"
+ThisBuild / tlBaseVersion := "0.29"
 ThisBuild / startYear := Some(2019)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(


### PR DESCRIPTION
brings `tlBaseVersion` up to speed in order to match the 0.29 release