### PR TITLE
Treat unsupplied query variables as an empty variables object

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -318,7 +318,14 @@ class QueryCompiler(parser: QueryParser, schema: Schema, phases: List[Phase]) {
    */
   def compileVars(varDefs: VarDefs, untypedVars: Option[Json]): Result[Vars] =
     untypedVars match {
-      case None => Map.empty.success
+      case None =>
+        // No variables supplied is equivalent to an empty variable values object: defaults
+        // apply, nullable variables are absent and non-nullable variables without defaults
+        // are errors, just as if they had been omitted from a supplied object.
+        varDefs
+          .traverse(iv =>
+            checkVarValue(iv, None, "variable values").map(v => (iv.name, (iv.tpe, v))))
+          .map(_.toMap)
       case Some(untypedVars) =>
         untypedVars.asObject match {
           case None =>

--- a/modules/core/src/test/scala/compiler/VariablesSuite.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSuite.scala
@@ -467,7 +467,7 @@ final class VariablesSuite extends CatsEffectSuite {
     assertEquals(compiled, expected)
   }
 
-  test("variable not defined (2)") {
+  test("variable declared but not provided is treated as absent") {
     val query = """
       query getZuckProfile($devicePicSize: Int) {
         user(id: 4) {
@@ -478,11 +478,23 @@ final class VariablesSuite extends CatsEffectSuite {
       }
     """
 
+    val expected =
+      UntypedSelect(
+        "user",
+        None,
+        List(Binding("id", IDValue("4"))),
+        Nil,
+        Group(
+          List(
+            UntypedSelect("id", None, Nil, Nil, Empty),
+            UntypedSelect("name", None, Nil, Nil, Empty),
+            UntypedSelect("profilePic", None, List(Binding("size", AbsentValue)), Nil, Empty)
+          ))
+      )
+
     val compiled = VariablesMapping.compiler.compile(query)
 
-    val expected = Result.failure("Variable 'devicePicSize' is undefined")
-
-    assertEquals(compiled, expected)
+    assertEquals(compiled.map(_.query), Result.Success(expected))
   }
 
   test("variable not defined (3)") {
@@ -530,7 +542,7 @@ final class VariablesSuite extends CatsEffectSuite {
       }
     """
 
-    val expected = Result.failure("Variable 'skipName' is undefined")
+    val expected = Result.failure("Expected Boolean found 'null' for 'if' in directive skip")
 
     val compiled = VariablesMapping.compiler.compile(query)
 
@@ -608,6 +620,61 @@ final class VariablesSuite extends CatsEffectSuite {
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
 
     assertEquals(compiled.toProblems.toList, List.empty[Problem])
+  }
+
+  test("variable in input value should be seen as 'used'") {
+    val query = """
+      query getZuckProfile($x: String) {
+        search(
+          pattern: {
+            name: $x
+          }
+        ) {
+          id
+        }
+      }
+    """
+
+    val compiled = VariablesMapping.compiler.compile(query, reportUnused = false)
+
+    assertEquals(compiled.toProblems.toList, List.empty[Problem])
+  }
+
+  test("variable in input value with explicit empty variables object") {
+    val query = """
+      query getZuckProfile($x: String) {
+        search(
+          pattern: {
+            name: $x
+          }
+        ) {
+          id
+        }
+      }
+    """
+
+    val compiled =
+      VariablesMapping
+        .compiler
+        .compile(query, reportUnused = false, untypedVars = Some(json"{}"))
+
+    assertEquals(compiled.toProblems.toList, List.empty[Problem])
+  }
+
+  test("non-nullable variable with no value provided is an error") {
+    val query = """
+      query getZuckProfile($x: Int!) {
+        user(id: 4) {
+          profilePic(size: $x)
+        }
+      }
+    """
+
+    val compiled = VariablesMapping.compiler.compile(query)
+
+    val expected = Result.failure("Value of type Int required for 'x' in variable values")
+
+    assertEquals(compiled.map(_.query), expected)
   }
 
   test("oneOf variables") {

--- a/modules/core/src/test/scala/compiler/VariablesSuite.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSuite.scala
@@ -635,9 +635,32 @@ final class VariablesSuite extends CatsEffectSuite {
       }
     """
 
-    val compiled = VariablesMapping.compiler.compile(query, reportUnused = false)
+    val compiled = VariablesMapping.compiler.compile(query)
 
     assertEquals(compiled.toProblems.toList, List.empty[Problem])
+  }
+
+  test("variable default applies when no variables are supplied") {
+    val query = """
+      query getZuckProfile($devicePicSize: Int = 60) {
+        user(id: 4) {
+          profilePic(size: $devicePicSize)
+        }
+      }
+    """
+
+    val expected =
+      UntypedSelect(
+        "user",
+        None,
+        List(Binding("id", IDValue("4"))),
+        Nil,
+        UntypedSelect("profilePic", None, List(Binding("size", IntValue(60))), Nil, Empty)
+      )
+
+    val compiled = VariablesMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
   }
 
   test("variable in input value with explicit empty variables object") {


### PR DESCRIPTION
**Note:** The current check failure is due to the usual `Your tlBaseVersion 0.28 is behind the latest tag 0.29.0`.

As a bit of an experiment, I put Claude to the task of figuring this one out. I have reviewed what I could and I have instructed Claude to adhere to proper test first etiquette and do a critical review of its own code but ultimately I am a bit out of my element here. This fix could be wrong. I am not deep enough into Grackle's compiler internals to deem this a correct fix or not. This being said: To me it looks fine. Also, the fix is very small, there is a reproducible test and the bug report is very recent.

And now without further ado, here is the PR text Claude proposed:

---

Fixes #743.

## Symptom

Compiling a query that references a declared variable — at a field argument or inside an input object literal — fails with a spurious `Variable 'x' is undefined` when no variables JSON is supplied:

```graphql
query getZuckProfile($x: String) {
  search(pattern: { name: $x }) {
    id
  }
}
```

The same query compiles fine with `untypedVars = Some(json"{}")`, which is the tell: per the spec ([CoerceVariableValues](https://spec.graphql.org/October2021/#sec-Coercing-Variable-Values)), an absent variable values map and an empty one must behave identically.

## Root cause

`compileVars` short-circuits to `Map.empty` when `untypedVars` is `None`, so declared variables never receive `Vars` entries. Any subsequent reference then fails the lookup in `Value.elaborateValue` with the misleading "undefined" error. The `Some` path instead coerces every declared variable via `checkVarValue`, which already handles absence correctly (defaults apply, nullable variables coerce to `AbsentValue`, non-nullable variables without defaults are errors).

Note this is not specific to input objects, despite how the issue was encountered — a plain `profilePic(size: $x)` with no variables supplied failed the same way. (The input-object variable *collection* bug in this area was fixed separately in #845; this reproducer still failed after it.)

## Fix

The `None` case now runs the same coercion as the `Some` path with every variable absent.

## Behaviour changes (all spec-aligned, review attention welcome)

Two existing test expectations codified the old behaviour and had to change:

1. **`variable not defined (2)`** (now *"variable declared but not provided is treated as absent"*): a declared nullable variable used in a nullable argument position now compiles successfully with the argument absent, instead of failing. This is the same mechanism as #743 — the issue could not be fixed while keeping this expectation.
2. **`variable not defined (5)`**: `@skip(if: $skipName)` with `$skipName` declared but unprovided still fails (a `Boolean!` position with no value), but now in directive argument validation (`Expected Boolean found 'null' for 'if' in directive skip`) rather than with the misleading `undefined` message.

Additionally:

3. A declared **non-nullable** variable without a default now errors at compile time when no variables are supplied (`Value of type Int required for 'x' in variable values`), even if unreferenced — matching both the spec and the existing behaviour when a variables object is supplied without that key.
4. Variable-level **default values** now apply when no variables are supplied (previously the empty `Vars` map ignored them entirely).

## Tests

- The reproducer from the `issue/743` branch (thanks @tpolecat), watched fail with the reported error before the fix, and run with unused-variable reporting enabled so it verifies the variable is seen as used.
- Equivalence pin: the same query with an explicit empty variables object (passes before *and* after the fix — the fix makes `None` consistent with it).
- Error pin for the non-nullable-unprovided case, and a pin for default-value application with no variables supplied.
- Full core suite passes on Scala 2.13 and 3 (546 tests), plus the circe and generic modules.
